### PR TITLE
Fix v2.6.6 not building on Xcode 12.5

### DIFF
--- a/ios/library/WhirlyGlobeLib/src/ScreenImportance.mm
+++ b/ios/library/WhirlyGlobeLib/src/ScreenImportance.mm
@@ -291,7 +291,7 @@ bool TileIsOnScreen(WhirlyKitViewState *viewState,WhirlyKit::Point2f frameSize,W
     }
     
     // This means the tile is degenerate (as far as we're concerned)
-    if ([dispSolid isKindOfClass:[NSNull null]])
+    if ([dispSolid isKindOfClass:[NSNull class]])
         return false;
 
     return [dispSolid isOnScreenForViewState:viewState frameSize:frameSize];


### PR DESCRIPTION
This is a proposal to fix the issue #1340.

I was able to compile and run on both Xcode 12.4 and 12.5 by applying this fix on top of release v2.6.6.
Didn't try with newer releases.