### PR TITLE
Make use of color and opacity expressions in wide vectors, performance wide vectors, and screen-space objects.

### DIFF
--- a/android/apps/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/MapTilerTestCase.kt
+++ b/android/apps/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/MapTilerTestCase.kt
@@ -67,14 +67,23 @@ open class MapTilerTestCase : MaplyTestCase
             }
         } ?: customStyle
     
-    // Switch maps on long press
+    // don't switch on long-press, it's too easy to do accidentally when pinching
     override fun userDidLongPress(globeControl: GlobeController?, selObjs: Array<SelectedObject?>?, loc: Point2d?, screenLoc: Point2d?) {
-        switchMaps()
     }
     override fun userDidLongPress(mapController: MapController?, selObjs: Array<SelectedObject?>?, loc: Point2d?, screenLoc: Point2d?) {
+    }
+    
+    // Switch maps on long tap
+    override fun userDidTap(globeControl: GlobeController?, loc: Point2d?, screenLoc: Point2d?) {
+        super.userDidTap(globeControl, loc, screenLoc)
         switchMaps()
     }
-
+    
+    override fun userDidTap(mapControl: MapController?, loc: Point2d?, screenLoc: Point2d?) {
+        super.userDidTap(mapControl, loc, screenLoc)
+        switchMaps()
+    }
+    
     private fun switchMaps() {
         currentMap = (currentMap + 1) % getMaps().size
         baseViewC?.let { setupLoader(it, currentMap) }
@@ -121,7 +130,48 @@ open class MapTilerTestCase : MaplyTestCase
                    "line-color":{"base":1,"stops":[[5,"hsl(26,87%,62%)"],[16,"#0f0"]]},
                    "line-width":{"base":1.2,"stops":[[5,0],[16,60]]}
                  }
-              }
+              },
+    {
+      "id": "road_minor",
+      "type": "line",
+      "source": "openmaptiles",
+      "source-layer": "transportation",
+      "filter": [
+        "all",
+        [
+          "==",
+          "${"$"}type",
+          "LineString"
+        ],
+        [
+          "in",
+          "class",
+          "minor",
+          "service"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
+      "paint": {
+        "line-color": "rgba(247, 247, 247, 0.12)",
+        "Xline-color": "rgba(247, 0, 0, 1.0)",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [
+              4,
+              0.25
+            ],
+            [
+              20,
+              10
+            ]
+          ]
+        }
+      }
+    }
            ],"sources":{"openmaptiles":{"type":"vector",
                  "url":"https://api.maptiler.com/tiles/v3/tiles.json?key=MapTilerKey"}}}
     """.trimIndent()

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleSetC.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleSetC.h
@@ -219,10 +219,10 @@ public:
     double doubleValue(const DictionaryEntryRef &entry,double defVal);
 
     /// @brief Return a double value for the given name, taking the constants into account
-    double doubleValue(const std::string &name,const DictionaryRef &dict,double defVal);
+    double doubleValue(const std::string &valName, const DictionaryRef &dict, double defVal);
         
     /// @brief Return a bool for the given name.  True if it matches the onString.  Default if it's missing
-    bool boolValue(const std::string &name,const DictionaryRef &dict,const std::string &onString,bool defVal);
+    bool boolValue(const std::string &valName, const DictionaryRef &dict, const std::string &onString, bool defVal);
 
     /// @brief Return a string for the given name, taking the constants into account
     std::string stringValue(const std::string &name,const DictionaryRef &dict,const std::string &defVal);
@@ -241,10 +241,10 @@ public:
     MapboxTransDoubleRef transDouble(const DictionaryEntryRef &entry,double defVal);
     
     /// Builds a transitionable double object from a style entry lookup and returns that
-    MapboxTransDoubleRef transDouble(const std::string &name,const DictionaryRef &entry,double defVal);
+    MapboxTransDoubleRef transDouble(const std::string &valName, const DictionaryRef &entry, double defVal);
 
     /// Builds a transitionable color object and returns that
-    MapboxTransColorRef transColor(const std::string &name,const DictionaryRef &entry,const RGBAColor *);
+    MapboxTransColorRef transColor(const std::string &valName, const DictionaryRef &entry, const RGBAColor *);
     MapboxTransColorRef transColor(const std::string &name,const DictionaryRef &entry,const RGBAColor &);
     
     /// Builds a transitional text object

--- a/common/WhirlyGlobeLib/include/WhirlyVector.h
+++ b/common/WhirlyGlobeLib/include/WhirlyVector.h
@@ -92,28 +92,65 @@ class RGBAColor
 {
 public:
 	RGBAColor() : RGBAColor(0,0,0,0) { }
-	RGBAColor(unsigned char r,unsigned char g,unsigned char b,unsigned char a) : r(r), g(g), b(b), a(a) { }
-	RGBAColor(unsigned char r,unsigned char g,unsigned char b) : r(r), g(g), b(b), a(255) { }
+
+    RGBAColor(int r,int g,int b,int a) :
+            r((uint8_t)r), g((uint8_t)g), b((uint8_t)b), a((uint8_t)a) { }
+    RGBAColor(int r,int g,int b) :
+            r((uint8_t)r), g((uint8_t)g), b((uint8_t)b), a(255) { }
 
 	template <typename T>
     RGBAColor(const Eigen::Matrix<T,4,1> &v) :
-        RGBAColor((unsigned char)(v.x()*255),(unsigned char)(v.y()*255),
-                  (unsigned char)(v.z()*255),(unsigned char)(v.w()*255)) { }
+        RGBAColor((uint8_t)(v.x()*255),(uint8_t)(v.y()*255),
+                  (uint8_t)(v.z()*255),(uint8_t)(v.w()*255)) { }
 
     RGBAColor withAlpha(int newA) const { return RGBAColor(r,g,b,(uint8_t)newA); }
+    RGBAColor withAlpha(float newA) const { return RGBAColor(r,g,b,(uint8_t)(newA * 255)); }
     RGBAColor withAlpha(double newA) const { return RGBAColor(r,g,b,(uint8_t)(newA * 255)); }
 
+    RGBAColor withAlphaMultiply(float newA) const {
+        return RGBAColor((uint8_t)(r*newA),(uint8_t)(g*newA),
+                         (uint8_t)(b*newA),(uint8_t)(newA * 255));
+	}
+    RGBAColor withAlphaMultiply(double newA) const {
+        return RGBAColor((uint8_t)(r*newA),(uint8_t)(g*newA),
+                         (uint8_t)(b*newA),(uint8_t)(newA * 255));
+    }
+
     // Create an RGBColor from unit floats
-    static RGBAColor FromUnitFloats(const float *ret) {
-        return RGBAColor(ret[0] * 255.0,ret[1] * 255.0,ret[2] * 255.0,ret[3] * 255.0);
+    static RGBAColor FromUnitFloats(const float *f) {
+        return FromUnitFloats4(f);
+    }
+    static RGBAColor FromUnitFloats3(const float *f) {
+        return FromUnitFloats(f[0],f[1],f[2]);
+    }
+    static RGBAColor FromUnitFloats4(const float *f) {
+        return FromUnitFloats(f[0],f[1],f[2],f[3]);
+    }
+    static RGBAColor FromUnitFloats(float r, float g, float b) {
+        return FromUnitFloats(r,g,b,1.0f);
+    }
+    static RGBAColor FromUnitFloats(float r, float g, float b, float a) {
+        return RGBAColor((uint8_t)(r * 255.0f),(uint8_t)(g * 255.0f),
+                         (uint8_t)(b * 255.0f),(uint8_t)(a * 255.0f));
+    }
+    static RGBAColor FromUnitFloats(double r, double g, double b) {
+        return FromUnitFloats(r,g,b,1.0);
+    }
+    static RGBAColor FromUnitFloats(double r, double g, double b, double a) {
+        return RGBAColor((uint8_t)(r * 255.0),(uint8_t)(g * 255.0),
+                         (uint8_t)(b * 255.0),(uint8_t)(a * 255.0));
     }
 
     template <typename T>
     static RGBAColor FromVec(const Eigen::Matrix<T,4,1> &v) { return RGBAColor(v); }
 
     // Create an RGBAColor from an int
-    static RGBAColor FromInt(int color) {
-	    return RGBAColor((color >> 16) & 0xff,(color >> 8)&0xff,color&0xff, color >> 24);
+    static RGBAColor FromInt(uint32_t color) { return FromARGBInt(color); }
+    static RGBAColor FromARGBInt(uint32_t color) {
+	    return RGBAColor((uint8_t)((color >> 16) & 0xff),
+                         (uint8_t)((color >> 8) & 0xff),
+                         (uint8_t)(color & 0xff),
+                         (uint8_t)(color >> 24));
 	}
     
     // Create an RGBAColor from HSV

--- a/common/WhirlyGlobeLib/src/DictionaryC.cpp
+++ b/common/WhirlyGlobeLib/src/DictionaryC.cpp
@@ -384,7 +384,7 @@ RGBAColor parseColor(const char* const p, RGBAColor ret)
     {
 #define DUP4(x) (uint8_t)((uint8_t)(x) | ((uint8_t)(x) << 4))   // 0N => NN
     case 3: // #RGB => R=RR G=GG B=BB A=FF
-        return RGBAColor(DUP4(v >> 8), DUP4(v >> 4), DUP4(v), 0xFF);
+        return RGBAColor(DUP4(v >> 8), DUP4(v >> 4), DUP4(v));
     case 4: // #ARGB => R=RR G=GG B=BB A=AA
         return RGBAColor(DUP4(v >> 8), DUP4(v >> 4), DUP4(v), DUP4(v >> 12));
 #undef DUP4

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleCircle.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleCircle.cpp
@@ -105,7 +105,7 @@ void MapboxVectorLayerCircle::buildObjects(PlatformThreadInfo *inst,
     // Default settings
     MarkerInfo markerInfo(/*screenObject=*/true);
     markerInfo.zoomSlot = styleSet->zoomSlot;
-    markerInfo.color = RGBAColor(255,255,255,opacity*255);
+    markerInfo.color = RGBAColor(255,255,255,(int)(opacity*255));
     markerInfo.drawPriority = drawPriority + tileInfo->ident.level * std::max(0, styleSet->tileStyleSettings->drawPriorityPerLevel) + 1;
     markerInfo.programID = styleSet->screenMarkerProgramID;
     

--- a/ios/apps/AutoTester/AutoTester/testCases/MapTilerTestCase.swift
+++ b/ios/apps/AutoTester/AutoTester/testCases/MapTilerTestCase.swift
@@ -46,7 +46,10 @@ class MapTilerTestCase: MaplyTestCase {
         }
         
         print("Starting map with \(style.name) / \(style.sheet)")
-        
+
+        globeViewController?.autoMoveToTap = false
+        mapViewController?.autoMoveToTap = false
+
         // Maptiler token
         // Go to maptiler.com, setup an account and get your own.
         // Go to Edit Scheme, select Run, Arguments, and add an "MAPTILER_TOKEN" entry to Environment Variables.
@@ -174,12 +177,21 @@ class MapTilerTestCase: MaplyTestCase {
         }
     }
 
-    override func maplyViewController(_ viewC: MaplyViewController, didTapAt coord: MaplyCoordinate) {
+    private func switchMaps() {
         mapboxMap?.stop()
         mapboxMap = nil
 
         mapTilerStyle = (mapTilerStyle + 1) % styles.count
-        startMap(styles[mapTilerStyle], viewC: viewC, round: false)
+        if let vc = baseViewController {
+            startMap(styles[mapTilerStyle], viewC: vc, round: false)
+        }
+    }
+
+    override func globeViewController(_ viewC: WhirlyGlobeViewController, didTapAt coord: MaplyCoordinate) {
+        switchMaps()
+    }
+    override func maplyViewController(_ viewC: MaplyViewController, didTapAt coord: MaplyCoordinate) {
+        switchMaps()
     }
 }
 

--- a/ios/apps/AutoTester/AutoTester/testCases/WideVectorsTestCase.m
+++ b/ios/apps/AutoTester/AutoTester/testCases/WideVectorsTestCase.m
@@ -235,6 +235,39 @@
 	return @[lines,screenLines,realLines,labelObj];
 }
 
+- (void)overlap:(MaplyBaseViewController *)viewC {
+
+    NSDictionary *wideDesc = @{
+        kMaplyColor: [UIColor colorWithRed:0 green:0 blue:1.0 alpha:0.2],
+        kMaplyFilled: @NO,
+        kMaplyEnable: @YES,
+        kMaplyFade: @0,
+        kMaplyDrawPriority: @(kMaplyVectorDrawPriorityDefault + 1),
+        kMaplyVecCentered: @YES,
+        kMaplyVecTexture: [NSNull null],
+        kMaplyWideVecEdgeFalloff:@(5),
+        kMaplyWideVecJoinType: kMaplyWideVecMiterJoin,
+        kMaplyWideVecCoordType: kMaplyWideVecCoordTypeScreen,
+        kMaplyWideVecCoordType: kMaplyWideVecCoordTypeScreen,
+        kMaplyWideVecOffset: @(10.0),
+        kMaplyWideVecMiterLimit: @(10.0),  // More than 10 degrees need a bevel join
+        kMaplyVecWidth: @(20.0),
+        kMaplyWideVecImpl: kMaplyWideVecImplPerf,//kMaplyWideVecImpl,
+    };
+
+    NSMutableArray* objs = [NSMutableArray new];
+    for (int i = 0; i < 5; ++i) {
+        MaplyCoordinate coords[2] = {
+            MaplyCoordinateMakeWithDegrees(-90 + i*2, 40),
+            MaplyCoordinateMakeWithDegrees(-80 - i*2, 30),
+        };
+        MaplyVectorObject *vecObj = [[MaplyVectorObject alloc] initWithLineString:&coords[0] numCoords:2 attributes:nil];
+        [vecObj subdivideToGlobe:0.0001];
+        [objs addObject:vecObj];
+    }
+    [viewC addWideVectors:objs desc:wideDesc mode:MaplyThreadCurrent];
+}
+
 - (void)wideLineTest:(MaplyBaseViewController *)viewC
 {
     [self addGeoJson:@"sawtooth.geojson" dashPattern:nil width:50.0 edge:20.0 simple:false viewC:viewC];
@@ -251,6 +284,7 @@
     //    [self addGeoJson:@"straight.geojson"];
     //    [self addGeoJson:@"uturn.geojson"];
     
+    [self overlap:viewC];
 }
 
 

--- a/ios/library/WhirlyGlobeLib/include/WrapperMTL.h
+++ b/ios/library/WhirlyGlobeLib/include/WrapperMTL.h
@@ -97,12 +97,12 @@ public:
     // Construct either track all buffers, or just track what we need to use()
     ResourceRefsMTL(bool trackHolds=false);
     
-    void addEntry(BufferEntryMTL &entry);
+    void addEntry(const BufferEntryMTL &entry);
     void addBuffer(id<MTLBuffer> buffer);
-    void addTexture(TextureEntryMTL &texture);
+    void addTexture(const TextureEntryMTL &texture);
     void addTextures(const std::vector<TextureEntryMTL> &textures);
 
-    void addResources(ResourceRefsMTL &other);
+    void addResources(const ResourceRefsMTL &other);
     
     // Wire up the resources listed
     void use(id<MTLRenderCommandEncoder> cmdEncode);
@@ -213,9 +213,11 @@ public:
 };
 
 /// Convert  a float expression into its Metal version
-void FloatExpressionToMtl(FloatExpressionInfoRef srcInfo,WhirlyKitShader::FloatExp &destExp);
+void FloatExpressionToMtl(const FloatExpressionInfoRef &srcInfo,
+                          WhirlyKitShader::FloatExp &destExp);
 
 /// Convert a color expression into its Metal version
-void ColorExpressionToMtl(ColorExpressionInfoRef srcInfo,WhirlyKitShader::ColorExp &destExp);
+void ColorExpressionToMtl(const ColorExpressionInfoRef &srcInfo,
+                          WhirlyKitShader::ColorExp &destExp);
 
 }

--- a/ios/library/WhirlyGlobeLib/src/wkDefaultShaders.metal
+++ b/ios/library/WhirlyGlobeLib/src/wkDefaultShaders.metal
@@ -373,8 +373,8 @@ vertex ProjVertexTriA vertexTri_noLightExp(
     if (vertArgs.uniDrawState.hasExp) {
         float zoom = ZoomFromSlot(uniforms, vertArgs.uniDrawState.zoomSlot);
         color = ExpCalculateColor(vertArgs.drawStateExp.colorExp, zoom, color);
-        float opacity = ExpCalculateFloat(vertArgs.drawStateExp.opacityExp, zoom, 1.0);
-        color.a = color.a * opacity;
+        float opacity = ExpCalculateFloat(vertArgs.drawStateExp.opacityExp, zoom, color.a);
+        color.a = /*color.a * */opacity;
     }
 
     outVert.color = color * calculateFade(uniforms,vertArgs.uniDrawState);
@@ -458,8 +458,8 @@ vertex ProjVertexTriA vertexTri_lightExp(
     if (vertArgs.uniDrawState.hasExp) {
         float zoom = ZoomFromSlot(uniforms, vertArgs.uniDrawState.zoomSlot);
         color = ExpCalculateColor(vertArgs.drawStateExp.colorExp, zoom, color);
-        float opacity = ExpCalculateFloat(vertArgs.drawStateExp.opacityExp, zoom, 1.0);
-        color.a = color.a * opacity;
+        float opacity = ExpCalculateFloat(vertArgs.drawStateExp.opacityExp, zoom, color.a);
+        color.a = /*color.a * */opacity;
     }
 
     outVert.color = resolveLighting(vert.position,
@@ -470,8 +470,7 @@ vertex ProjVertexTriA vertexTri_lightExp(
                     calculateFade(uniforms,vertArgs.uniDrawState);
     if (TexturesBase(texArgs.texPresent) > 0)
         outVert.texCoord = resolveTexCoords(vert.texCoord,texArgs,0);
-    outVert.color = color;
-    
+
     return outVert;
 }
 
@@ -525,7 +524,6 @@ vertex ProjVertexTriB vertexTri_multiTex(
                                     lighting,
                                     uniforms.mvpMatrix) *
                     calculateFade(uniforms,vertArgs.uniDrawState);
-    outVert.color = vert.color;
 
     // Handle the various texture coordinate input options (none, 1, or 2)
     int numTextures = TexturesBase(texArgs.texPresent);
@@ -687,7 +685,13 @@ vertex ProjVertexTriWideVec vertexTri_wideVecExp(
     }
     centerLine = vert.offset.z * centerLine;
 
-    outVert.color = vert.color * calculateFade(uniforms,vertArgs.uniDrawState);
+    float4 color = vert.color;
+    if (vertArgs.wideVec.hasExp) {
+        color = ExpCalculateColor(vertArgs.wideVecExp.colorExp, zoom, color);
+        float opacity = ExpCalculateFloat(vertArgs.wideVecExp.opacityExp, zoom, color.a);
+        color.a = /*color.a * */opacity;
+    }
+    outVert.color = color * calculateFade(uniforms,vertArgs.uniDrawState);
     
     float pixScale = min(uniforms.screenSizeInDisplayCoords.x,uniforms.screenSizeInDisplayCoords.y) / min(uniforms.frameSize.x,uniforms.frameSize.y);
     float realWidth2 = w2 * pixScale;
@@ -952,8 +956,15 @@ vertex ProjVertexTriWideVecPerf vertexTri_wideVecPerf(
             }
         }
     }
-    
-    outVert.color = inst[1].color * calculateFade(uniforms,vertArgs.uniDrawState);
+
+    float4 color = inst[1].color;
+    if (vertArgs.wideVec.hasExp) {
+        color = ExpCalculateColor(vertArgs.wideVecExp.colorExp, zoom, color);
+        float opacity = ExpCalculateFloat(vertArgs.wideVecExp.opacityExp, zoom, color.a);
+        color.a = /*color.a * */opacity;
+    }
+    outVert.color = color * calculateFade(uniforms,vertArgs.uniDrawState);
+
     outVert.w2 = vertArgs.wideVec.w2;
     
     if (isValid && dotProd > 0.0) {
@@ -1078,7 +1089,14 @@ vertex ProjVertexTriA vertexTri_screenSpaceExp(
     if (vertArgs.ss.hasMotion)
         pos += (uniforms.currentTime - vertArgs.ss.startTime) * vert.dir;
     
-    outVert.color = vert.color * calculateFade(uniforms,vertArgs.uniDrawState);
+    float4 color = vert.color;
+    if (vertArgs.ss.hasExp) {
+        color = ExpCalculateColor(vertArgs.ssExp.colorExp, zoomScale, color);
+        float opacity = ExpCalculateFloat(vertArgs.ssExp.opacityExp, zoomScale, color.a);
+        color.a = /*color.a * */opacity;
+    }
+
+    outVert.color = color * calculateFade(uniforms,vertArgs.uniDrawState);
     outVert.texCoord = vert.texCoord;
     
     // Convert from model space into display space


### PR DESCRIPTION
Replace alpha with calculated rather than multiplying.
Use exponent base in color expression.
The calculated color with fade and light was being overwritten with a previous value in the basic vertex with expressions and multi-texture cases.

I've only looked at the MapTiler case briefly so far, but this obviously each of these needs to be checked.