### PR TITLE
Add support for stops in text fields.

### DIFF
--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleSetC.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleSetC.h
@@ -50,17 +50,32 @@ public:
 class MapboxRegexField {
 public:
     MapboxRegexField() : valid(false) { }
+    MapboxRegexField(const MapboxRegexField &other) :
+        chunks(other.chunks),
+        valid(other.valid)
+    { }
+    MapboxRegexField(MapboxRegexField &&other) :
+        chunks(std::move(other.chunks)),
+        valid(other.valid)
+    {
+        other.valid = false;
+    }
 
     // Simpler version that just takes the text string
     bool parse(const std::string &textVal);
+
     // Parse the regex text field out of a field name string
-    bool parse(const std::string &fieldName,MapboxVectorStyleSetImpl *styleSet,const DictionaryRef &styleEntry);
+    bool parse(const std::string &fieldName,
+               MapboxVectorStyleSetImpl *styleSet,
+               const DictionaryRef &styleEntry);
     
     // Build the field based on the attributes
-    std::string build(const DictionaryRef &attrs);
-    
+    std::string build(const DictionaryRef &attrs) const;
+
+    // Build a string for debug output
+    std::string buildDesc(const DictionaryRef &attrs) const;
+
     std::vector<MapboxTextChunk> chunks;
-    
     bool valid;
 };
 

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleSymbol.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleSymbol.h
@@ -63,7 +63,7 @@ public:
     float layoutImportance;
         
     // Text can be expressed in a complex way
-    MapboxRegexField textField;
+    MapboxTransTextRef textField;
 
     // Name of icon, if present, can be expressed the same way as text
     MapboxTransTextRef iconImageField;


### PR DESCRIPTION
I found a couple examples like this in the stylesheets:

`{"text-field":{"base":1,"stops":[[0,"{abbr}"],[6,"{name_en}"]]}}`

