### PR TITLE
Add a 1-pixel buffer around glyphs to avoid picking up extra pixels f…

### DIFF
--- a/android/library/maply/WhirlyGlobeLib/src/FontTextureManager_Android.cpp
+++ b/android/library/maply/WhirlyGlobeLib/src/FontTextureManager_Android.cpp
@@ -208,7 +208,7 @@ DrawableString *FontTextureManager_Android::addString(
 						                       glyphSize.y() + 2 * textureOffset.y());
 						std::vector<Texture *> texs{&tex};
 						if (texAtlas->addTexture(sceneRender, texs, -1, &realSize, nullptr, subTex,
-												 changes, 0, 0, nullptr))
+												 changes, 0, 1, nullptr))
 						{
 							glyphInfo = fm->addGlyph(glyph, subTex,
 													 Point2f(glyphSize.x(), glyphSize.y()),

--- a/common/WhirlyGlobeLib/src/DynamicTextureAtlas.cpp
+++ b/common/WhirlyGlobeLib/src/DynamicTextureAtlas.cpp
@@ -108,8 +108,10 @@ bool DynamicTexture::findRegion(int sizeX,int sizeY,Region &region)
         releasedRegions.clear();
     }
 
-    for (unsigned int ii=0;ii<toClear.size();ii++)
-        setRegion(toClear[ii], false);
+    for (auto &ii : toClear)
+    {
+        setRegion(ii, false);
+    }
     
     // Now look for a region that'll fit
     // Look for a spot big enough
@@ -279,9 +281,10 @@ bool DynamicTextureAtlas::addTexture(SceneRenderer *sceneRender,const std::vecto
     }
     
     // Now look for space
-    DynamicTextureVec *dynTexVec = NULL;
+    DynamicTextureVec *dynTexVec = nullptr;
     bool found = false;
-    int numCellX = ceil((firstTex->getWidth()+bufferPixels) / (float)cellSize), numCellY = ceil((firstTex->getHeight()+bufferPixels) / (float)cellSize);
+    const int numCellX = ceil((float)(firstTex->getWidth()+bufferPixels) / (float)cellSize);
+    const int numCellY = ceil((float)(firstTex->getHeight()+bufferPixels) / (float)cellSize);
     for (auto it = textures.begin(); it != textures.end(); ++it)
     {
         DynamicTextureVec *dynTex = *it;
@@ -332,16 +335,16 @@ bool DynamicTextureAtlas::addTexture(SceneRenderer *sceneRender,const std::vecto
     
     if (found)
     {
-        DynamicTextureRef dynTex0 = dynTexVec->at(0);
+        const DynamicTextureRef &dynTex0 = dynTexVec->at(0);
         dynTex0->setRegion(texRegion.region, true);
         dynTex0->getNumRegions()++;
         
         for (unsigned int ii=0;ii<newTextures.size();ii++)
         {
             // If there's only one frame, we're updating that
-            int which = frame == -1 ? ii : frame;
+            const int which = frame == -1 ? ii : frame;
             Texture *tex = newTextures[newTextures.size() == 1 ? 0 : which];
-            DynamicTextureRef dynTex = dynTexVec->at(which);
+            const DynamicTextureRef &dynTex = dynTexVec->at(which);
             //        NSLog(@"Region: (%d,%d)->(%d,%d)  texture: %ld",texRegion.region.sx,texRegion.region.sy,texRegion.region.ex,texRegion.region.ey,dynTex->getId());
             // Make the main thread do the merge
             if (MainThreadMerge || mainThreadMerge)
@@ -353,10 +356,11 @@ bool DynamicTextureAtlas::addTexture(SceneRenderer *sceneRender,const std::vecto
         }
 
         // This asks for a flush
-        changes.push_back(NULL);
+        changes.push_back(nullptr);
 
         // This way does not take into account borders
-        TexCoord org((texRegion.region.sx * cellSize) / (float)texSize, (texRegion.region.sy * cellSize) / (float)texSize);
+        TexCoord org((texRegion.region.sx * cellSize) / (float)texSize,
+                     (texRegion.region.sy * cellSize) / (float)texSize);
 //        texRegion.subTex.setFromTex(TexCoord(org.x(),org.y()),
 //                                    TexCoord(org.x() + tex->getWidth() / (float)texSize , org.y() + tex->getHeight() / (float)texSize));
         

--- a/ios/library/WhirlyGlobeLib/src/FontTextureManager_iOS.mm
+++ b/ios/library/WhirlyGlobeLib/src/FontTextureManager_iOS.mm
@@ -299,7 +299,7 @@ WhirlyKit::DrawableString *FontTextureManager_iOS::addString(PlatformThreadInfo 
                         Point2f realSize(glyphSize.x()+2*textureOffset.x(),glyphSize.y()+2*textureOffset.y());
                         std::vector<Texture *> texs;
                         texs.push_back(tex);
-                        if (texAtlas->addTexture(sceneRender, texs, -1, &realSize, NULL, subTex, changes, 0))
+                        if (texAtlas->addTexture(sceneRender, texs, -1, &realSize, NULL, subTex, changes, 0, 1))
                             glyphInfo = fm->addGlyph(glyph, subTex, Point2f(glyphSize.x(),glyphSize.y()), offset, textureOffset);
                         delete tex;
                     }


### PR DESCRIPTION
…rom neighboring glyphs either due to a texture coordinate error or simply from scaling oversampling.

![image](https://user-images.githubusercontent.com/71895881/121935791-b4f9e400-ccfd-11eb-96ae-39f387b5a0c9.png)
