### PR TITLE
Look for image file magic numbers to usually guess correctly whether tile data is an image or vector data

### DIFF
--- a/android/apps/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/OpenMapTilesHybridTestCase.kt
+++ b/android/apps/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/OpenMapTilesHybridTestCase.kt
@@ -70,7 +70,7 @@ class OpenMapTilesHybridTestCase : MaplyTestCase {
         lineStyleGen = VectorStyleSimpleGenerator(control)
 
         // The interpreter renders some of the data into images and overlays the rest
-        interp = MapboxVectorInterpreter(polyStyleGen, tileRenderer, lineStyleGen, control)
+        interp = MapboxVectorInterpreter(polyStyleGen!!, tileRenderer!!, lineStyleGen!!, control)
 
         // Finally the loader asks for tiles
         loader = QuadImageLoader(params,tileInfo,control)


### PR DESCRIPTION
Check for failed remote tile fetches to avoid passing error messages as tile data.
Fix warnings.
Resolves #1329.