### PR TITLE
Copy zoom slots to offline renderer so that expression-based drawables render correctly

### DIFF
--- a/android/library/maply/jni/include/generated/com_mousebird_maply_Scene.h
+++ b/android/library/maply/jni/include/generated/com_mousebird_maply_Scene.h
@@ -49,6 +49,23 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_Scene_removeRenderTargetNative
 
 /*
  * Class:     com_mousebird_maply_Scene
+ * Method:    getZoomSlotValue
+ * Signature: (I)F
+ */
+JNIEXPORT float JNICALL Java_com_mousebird_maply_Scene_getZoomSlotValue
+  (JNIEnv *env, jobject obj, jint slot);
+
+/*
+ * Class:     com_mousebird_maply_Scene
+ * Method:    copyZoomSlots
+ * Signature: (Lcom/mousebird/maply/Scene;F)V
+ * Signature: (Lcom/mousebird/maply/Scene;F)V
+ */
+JNIEXPORT void JNICALL Java_com_mousebird_maply_Scene_copyZoomSlots
+  (JNIEnv *env, jobject obj, jobject, jfloat);
+
+/*
+ * Class:     com_mousebird_maply_Scene
  * Method:    teardownGL
  * Signature: ()V
  */

--- a/android/library/maply/jni/src/scene/Scene_jni.cpp
+++ b/android/library/maply/jni/src/scene/Scene_jni.cpp
@@ -210,3 +210,38 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_Scene_removeRenderTargetNative(J
         __android_log_print(ANDROID_LOG_ERROR, "Maply", "Crash in Scene::removeRenderTargetNative()");
     }
 }
+
+extern "C"
+JNIEXPORT float JNICALL Java_com_mousebird_maply_Scene_getZoomSlotValue(JNIEnv *env, jobject obj, jint slot)
+{
+    try
+    {
+        SceneClassInfo *classInfo = SceneClassInfo::getClassInfo();
+        if (Scene *scene = classInfo->getObject(env,obj))
+        {
+            return scene->getZoomSlotValue(slot);
+        }
+    }
+    catch (...)
+    {
+        __android_log_print(ANDROID_LOG_ERROR, "Maply", "Crash in Scene::getZoomSlotValue()");
+    }
+}
+
+extern "C"
+JNIEXPORT void JNICALL Java_com_mousebird_maply_Scene_copyZoomSlots(JNIEnv *env, jobject obj, jobject otherObj, jfloat offset)
+{
+    try
+    {
+        SceneClassInfo *classInfo = SceneClassInfo::getClassInfo();
+        if (Scene *thisScene = classInfo->getObject(env,obj))
+        if (Scene *otherScene = classInfo->getObject(env,otherObj))
+        {
+            thisScene->copyZoomSlotsFrom(otherScene, offset);
+        }
+    }
+    catch (...)
+    {
+        __android_log_print(ANDROID_LOG_ERROR, "Maply", "Crash in Scene::copyZoomSlots()");
+    }
+}

--- a/android/library/maply/src/main/java/com/mousebird/maply/MapboxVectorInterpreter.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/MapboxVectorInterpreter.java
@@ -309,6 +309,11 @@ public class MapboxVectorInterpreter implements LoaderInterpreter
                     try {
                         tileRender.setEGLContext(null);
 
+                        // Copy the zoom slot values from the scene into the renderer's scene,
+                        // adding half a level to each to approximate the half-way point between
+                        // here and the next level where we'll generate a new tile image.
+                        tileRender.getScene().copyZoomSlots(theVC.getScene(), 0.5f);
+
                         for (byte[] data : pbfData) {
                             if (!imageParser.parseData(data, imageTileData, loadReturn) || loadReturn.isCanceled()) {
                                 if (loadReturn.isCanceled()) {

--- a/android/library/maply/src/main/java/com/mousebird/maply/Scene.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/Scene.java
@@ -36,9 +36,17 @@ public class Scene
 	 */
 	public native void addShaderProgram(Shader shader);
 	public native void removeShaderProgram(long shaderID);
+
 	public native void addRenderTargetNative(long renderTargetID,int width,int height,long texID,boolean clearEveryFrame,float clearVal,boolean blend,float red,float green,float blue,float alpha);
 	public native void changeRenderTarget(long renderTargetID,long texID);
 	public native void removeRenderTargetNative(long renderTargetID);
+
+	public native float getZoomSlotValue(int slot);
+
+	/**
+	 * Copy the zoom slot values from another scene, adding <c>offset</c> to each
+	 */
+	public native void copyZoomSlots(Scene otherScene, float offset);
 
 	/**
 	 * Tear down the OpenGL resources.  Context needs to be set first.

--- a/common/WhirlyGlobeLib/include/Scene.h
+++ b/common/WhirlyGlobeLib/include/Scene.h
@@ -392,8 +392,12 @@ public:
     float getZoomSlotValue(int zoomSlot) const;
     
     /// Copy all the zoom slots into a destination array
-    void copyZoomSlots(float *dest);
-	
+    // dest must be at least MaplyMaxZoomSlots
+    void copyZoomSlots(float *dest) const;
+
+    /// Copy all zoom slot values from the given scene object
+    void copyZoomSlotsFrom(const Scene *otherScene, float offset = 0.0f);
+
     /// Add a shader for reference, but not with a scene name.
     /// Presumably you'll call setSceneProgram() shortly.
     void addProgram(ProgramRef prog);

--- a/common/WhirlyGlobeLib/include/SceneRendererGLES.h
+++ b/common/WhirlyGlobeLib/include/SceneRendererGLES.h
@@ -102,7 +102,7 @@ public:
     /// Construct a billboard drawable builder for the current rendering type
     virtual BillboardDrawableBuilderRef makeBillboardDrawableBuilder(const std::string &name) const;
     
-    /// Construct a screnspace drawable builder for the current rendering type
+    /// Construct a screen-space drawable builder for the current rendering type
     virtual ScreenSpaceDrawableBuilderRef makeScreenSpaceDrawableBuilder(const std::string &name) const;
     
     /// Construct a particle system builder of the appropriate rendering type

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleFill.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleFill.cpp
@@ -155,7 +155,7 @@ void MapboxVectorLayerFill::buildObjects(PlatformThreadInfo *inst,
             // TODO: Switch to stencils
 //            vecInfo.drawOrder = tileInfo->tileNumber();
 
-//            wkLogLevel(Debug, "fill: tildID = %d: (%d,%d)  drawOrder = %d, drawPriority = %d",tileInfo->ident.level, tileInfo->ident.x, tileInfo->ident.y, vecInfo.drawOrder,vecInfo.drawPriority);
+//            wkLogLevel(Debug, "fill: tileID = %d: (%d,%d)  drawOrder = %d, drawPriority = %d",tileInfo->ident.level, tileInfo->ident.x, tileInfo->ident.y, vecInfo.drawOrder,vecInfo.drawPriority);
 
             if (minzoom != 0 || maxzoom < 1000)
             {

--- a/common/WhirlyGlobeLib/src/Scene.cpp
+++ b/common/WhirlyGlobeLib/src/Scene.cpp
@@ -609,10 +609,30 @@ float Scene::getZoomSlotValue(int zoomSlot) const
     return (zoomSlot < 0 || zoomSlot >= MaplyMaxZoomSlots) ? 0.0f : zoomSlots[zoomSlot];
 }
 
-void Scene::copyZoomSlots(float *dest)
+void Scene::copyZoomSlots(float *dest) const
 {
     std::lock_guard<std::mutex> guardLock(zoomSlotLock);
     std::copy(&zoomSlots[0], &zoomSlots[MaplyMaxZoomSlots], dest);
+}
+
+void Scene::copyZoomSlotsFrom(const Scene *otherScene, float offset)
+{
+    if (otherScene)
+    {
+        std::lock_guard<std::mutex> guardLock(zoomSlotLock);
+        otherScene->copyZoomSlots(&zoomSlots[0]);
+
+        if (offset != 0.0f)
+        {
+            for (auto &slot : zoomSlots)
+            {
+                if (slot != MAXFLOAT)
+                {
+                    slot += offset;
+                }
+            }
+        }
+    }
 }
 
 void AddTextureReq::setupForRenderer(const RenderSetupInfo *setupInfo,Scene *scene)

--- a/doc/TestCaseStatus.yaml
+++ b/doc/TestCaseStatus.yaml
@@ -435,8 +435,6 @@ cases:
   Android:
     Map: ✓Partial
     Globe: ✓Partial
-      Issues: 
-        - Streets case landuse not working with `backgroundAllPolys`
     Issues: 
       - Multiple sources not working (e.g., topo)
       - Loader sometimes not shutting down when cycling styles?


### PR DESCRIPTION
I built the zoom slot offset into the copy call to avoid making a JNI call for each.  A little ugly, but it works.