### PR TITLE
Add cancellation to the layout process.

### DIFF
--- a/android/library/maply/jni/include/generated/com_mousebird_maply_LayoutManager.h
+++ b/android/library/maply/jni/include/generated/com_mousebird_maply_LayoutManager.h
@@ -25,6 +25,14 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_LayoutManager_updateLayout
 
 /*
  * Class:     com_mousebird_maply_LayoutManager
+ * Method:    cancelUpdate
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL Java_com_mousebird_maply_LayoutManager_cancelUpdate
+        (JNIEnv *, jobject);
+
+/*
+ * Class:     com_mousebird_maply_LayoutManager
  * Method:    hasChanges
  * Signature: ()Z
  */

--- a/android/library/maply/jni/src/layoutSelection/LayoutManager_jni.cpp
+++ b/android/library/maply/jni/src/layoutSelection/LayoutManager_jni.cpp
@@ -435,6 +435,27 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_LayoutManager_updateLayout
     }
 }
 
+
+extern "C"
+JNIEXPORT void JNICALL Java_com_mousebird_maply_LayoutManager_cancelUpdate
+        (JNIEnv *env, jobject obj)
+{
+    try
+    {
+        if (auto wrap = LayoutManagerWrapperClassInfo::get(env, obj))
+        {
+            if (auto lm = wrap->layoutManager)
+            {
+                lm->cancelUpdate();
+            }
+        }
+    }
+    catch (...)
+    {
+        __android_log_print(ANDROID_LOG_ERROR, "Maply", "Crash in LayoutManager::cancelUpdate()");
+    }
+}
+
 extern "C"
 JNIEXPORT jboolean JNICALL Java_com_mousebird_maply_LayoutManager_hasChanges(JNIEnv *env, jobject obj)
 {

--- a/android/library/maply/src/main/java/com/mousebird/maply/Layer.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/Layer.java
@@ -20,6 +20,8 @@
 
 package com.mousebird.maply;
 
+import androidx.annotation.CallSuper;
+
 /**
  * The Layer subclass is used by the LayerThread to track Maply
  * objects that need to be updated on a regular basis.  The various
@@ -38,7 +40,7 @@ public class Layer
 	 * been started on the thread and can hook itself into the system, generating
 	 * geometry or registering for view changes and such.
 	 * 
-	 * @param inLayerThread
+	 * @param inLayerThread The thread to run on
 	 */
 	public void startLayer(LayerThread inLayerThread)
 	{
@@ -58,6 +60,8 @@ public class Layer
 	 * This method is called when a layer is to be removed.  The layer should
 	 * clean up any objects it may have created.
 	 * <p>
+	 * Called from the layer thread.
+	 * <p>
 	 * If the MaplyController is shut down, you may not get this call and instead
 	 * may simply be deleted.
 	 */
@@ -65,5 +69,14 @@ public class Layer
 	{
 	}
 
-	boolean isShuttingDown = false;
+	/**
+	 * This method is called when the layer will soon be shut down,
+	 * but outside any lock context and from another thread.
+	 */
+	@CallSuper
+	public void preShutdown() {
+		isShuttingDown = true;
+	}
+
+	protected boolean isShuttingDown = false;
 }

--- a/android/library/maply/src/main/java/com/mousebird/maply/LayerThread.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/LayerThread.java
@@ -28,6 +28,7 @@ import com.mousebirdconsulting.whirlyglobemaply.BuildConfig;
 import java.util.ArrayList;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 import javax.microedition.khronos.egl.EGL10;
@@ -243,8 +244,7 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 
 	// Used to shut down cleaning without cutting off outstanding work threads
 	public boolean isShuttingDown = false;
-	private final Semaphore workLock = new Semaphore(1, true);
-	private int numActiveWorkers = 0;
+	private final AtomicInteger numActiveWorkers = new AtomicInteger(0);
 
 	/**
 	 * Something is requesting a lock on shutting down while working
@@ -258,42 +258,17 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 			return false;
 		}
 
-		try {
-			workLock.acquire();
-		} catch (Exception ignored) {
-			return false;
-		}
-
-		try {
-			// Check it again now that we might have waited for a while
-			if (!isShuttingDown) {
-				numActiveWorkers = numActiveWorkers + 1;
-				return true;
-			}
-		} finally {
-			try {
-				workLock.release();
-			} catch (Exception ignored) {
-			}
-		}
-
-		return false;
+		numActiveWorkers.incrementAndGet();
+		return true;
 	}
 
 	// End of an external work block.  Safe to shut down.
 	public void endOfWork()
 	{
-		try {
-			workLock.acquire();
-			numActiveWorkers = numActiveWorkers - 1;
-			if (numActiveWorkers < 0) {
-				// If you see this, it probably means you called `startOfWork` and didn't
-				// check the result.  If it returns false, you must not call `endOfWork`.
-				Log.e("Maply", "Unbalanced endOfWork");
-			}
-			workLock.release();
-		}
-		catch (Exception ignored) {
+		if (numActiveWorkers.decrementAndGet() < 0) {
+			// If you see this, it probably means you called `startOfWork` and didn't
+			// check the result.  If it returns false, you must not call `endOfWork`.
+			Log.e("Maply", "Unbalanced endOfWork");
 		}
 	}
 	
@@ -320,20 +295,14 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 		// Wait for anything outstanding to finish before we shut down
 		try {
 			final long t0 = System.nanoTime();
-			do {
-				workLock.acquire();
-				if (numActiveWorkers <= 0) {
-					workLock.release();
-					break;
-				}
-				workLock.release();
+			while (numActiveWorkers.get() > 0) {
 				if (System.nanoTime() - t0 > 2L * 1000L * 1000L * 1000L) {
 					Log.w("Maply", "LayerThread timed out waiting for workers");
 					break;
 				}
 				//noinspection BusyWait
-				sleep(10);
-			} while (true);
+				sleep(25);
+			}
 		} catch (InterruptedException ignored) {
 			// we took too long
 			Log.w("Maply", "LayerThread interrupted while waiting for workers");
@@ -344,7 +313,7 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 
 		synchronized (layers) {
 			for (final Layer layer : layers) {
-				layer.isShuttingDown = true;
+				layer.preShutdown();
 			}
 		}
 
@@ -525,8 +494,7 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 	 * @param run Runnable to run
 	 * @return The Handler if you want to cancel this at some point in the future.
 	 */
-	public Handler addTask(Runnable run)
-	{
+	public Handler addTask(Runnable run) {
 		return addTask(run,false);
 	}
 	
@@ -537,11 +505,23 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 	 * @param time time Number of milliseconds to wait before running.
 	 * @return The Handler if you want to cancel this at some point in the future.
 	 */
-	public Handler addDelayedTask(Runnable run,long time)
-	{
+	public Handler addDelayedTask(Runnable run,long time) {
+		return addDelayedTask(run, time, true);
+	}
+
+	/**
+	 * Add a Runnable to the queue, but only execute after the given amount of time.
+	 *
+	 * @param run Runnable to add to the queue
+	 * @param time time Number of milliseconds to wait before running.
+	 * @param unitOfWork If true, the runnable will be bracketed with
+	 *                   <c>startOfWork</c> and <c>endOfWork</c> calls
+	 * @return The Handler if you want to cancel this at some point in the future.
+	 */
+	public Handler addDelayedTask(Runnable run,long time,boolean unitOfWork) {
 		if (valid && run != null) {
 			Handler handler = new Handler(getLooper());
-			handler.postDelayed(() -> runWorkRunnable(run, true), time);
+			handler.postDelayed(unitOfWork ? () -> runWorkRunnable(run, true) : run, time);
 			return handler;
 		}
 		return null;

--- a/android/library/maply/src/main/java/com/mousebird/maply/LayerThread.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/LayerThread.java
@@ -295,9 +295,16 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 		// Wait for anything outstanding to finish before we shut down
 		try {
 			final long t0 = System.nanoTime();
-			while (numActiveWorkers.get() > 0) {
-				if (System.nanoTime() - t0 > 2L * 1000L * 1000L * 1000L) {
-					Log.w("Maply", "LayerThread timed out waiting for workers");
+			while (true) {
+				final long t1 = System.nanoTime();
+				final int count = numActiveWorkers.get();
+				if (count <= 0) {
+					break;
+				}
+				if (t1 - t0 > 2L * 1000L * 1000L * 1000L) {
+					Log.w("Maply",
+							String.format("LayerThread timed out waiting for %d workers after %f s",
+										  count, (t1 - t0) / 1.0e9));
 					break;
 				}
 				//noinspection BusyWait

--- a/android/library/maply/src/main/java/com/mousebird/maply/LayoutManager.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/LayoutManager.java
@@ -30,13 +30,11 @@ class LayoutManager
 	@SuppressWarnings("unused")		// Referenced by JNI
 	private LayoutManager() { }
 	
-	protected LayoutManager(Scene scene)
-	{
+	protected LayoutManager(Scene scene) {
 		initialise(scene);
 	}
 	
-	public void finalize()
-	{
+	public void finalize() {
 		dispose();
 	}
 	
@@ -55,7 +53,12 @@ class LayoutManager
 	 * @param changes Changes to propagate to the scene.
 	 */
 	public native void updateLayout(ViewState viewState,ChangeSet changes);
-	
+
+	/**
+	 * Cancel the update in progress, if any.
+	 */
+	public native void cancelUpdate();
+
 	/**
 	 * True if there were any changes since layout was last run.
 	 */
@@ -92,5 +95,7 @@ class LayoutManager
 	private static native void nativeInit();
 	native void initialise(Scene scene);
 	native void dispose();
+
+	@SuppressWarnings("unused")		// Referenced by JNI
 	private long nativeHandle;
 }

--- a/common/WhirlyGlobeLib/include/Expect.h
+++ b/common/WhirlyGlobeLib/include/Expect.h
@@ -1,0 +1,53 @@
+/*  Expect.h
+ *  WhirlyGlobeLib
+ *
+ *  Created by Tim Sylvester on 7/22/2021
+ *  Copyright 2021-2021 mousebird consulting
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// EXPECT provides the compiler with branch prediction information.
+// EXPECT takes two integral arguments: a value, and the expected result, and evaluates to the former.
+// The compiler uses the `builtin-expect-probability` parameter as the probability, defaulting to 0.9.
+// EXPECT_WITH_PROBABILITY allows specifying the probability directly.
+
+#if !defined(EXPECT)
+# if (defined(__clang__) && __has_builtin(expect)) || (__GNUC__ > 3)
+#  define EXPECT(x,v) __builtin_expect(!!(x), v)
+# else
+#  define EXPECT(x,v) (x)
+# endif
+#endif
+
+#if !defined(EXPECT_WITH_PROBABILITY)
+# if defined(__clang__) && defined(__has_builtin)
+#  define EXPECT_WITH_PROBABILITY(x,b,p) __builtin_expect_with_probability(!!(x), v, p)
+# else
+#  define EXPECT_WITH_PROBABILITY(x,v,p) (x)
+# endif
+#endif
+
+#if !defined(LIKELY)
+# define LIKELY(x) EXPECT(x, 1)
+#endif
+#if !defined(UNLIKELY)
+# define UNLIKELY(x) EXPECT(x, 0)
+#endif
+
+#if !defined(LIKELY)
+# define LIKELY(x) EXPECT(x, 1)
+#endif
+#if !defined(UNLIKELY)
+# define UNLIKELY(x) EXPECT(x, 0)
+#endif
+

--- a/common/WhirlyGlobeLib/include/LayoutManager.h
+++ b/common/WhirlyGlobeLib/include/LayoutManager.h
@@ -236,7 +236,10 @@ public:
     
     /// Run the layout logic for everything we're aware of (thread safe)
     void updateLayout(PlatformThreadInfo *threadInfo,const ViewStateRef &viewState,ChangeSet &changes);
-    
+
+    /// Cancel the update in progress
+    void cancelUpdate();
+
     /// True if we've got changes since the last update
     bool hasChanges();
     
@@ -291,6 +294,8 @@ protected:
     int maxDisplayObjects;
     /// If there were updates since the last layout
     bool hasUpdates;
+    /// Cancel a layout run in progress
+    bool cancelLayout;
     /// Enable drawing layout boundaries
     bool showDebugBoundaries;
     /// Objects we're controlling the placement for

--- a/common/WhirlyGlobeLib/include/OverlapHelper.h
+++ b/common/WhirlyGlobeLib/include/OverlapHelper.h
@@ -84,7 +84,7 @@ public:
     void addObject(LayoutObjectEntryRef objEntry,const Point2dVector &pts);
 
     // Deal with cluster to cluster overlap
-    void resolveClusters();
+    void resolveClusters(volatile bool &cancel);
     
     // Single object with its bounds
     struct ObjectWithBounds

--- a/common/WhirlyGlobeLib/src/LayoutManager.cpp
+++ b/common/WhirlyGlobeLib/src/LayoutManager.cpp
@@ -1229,8 +1229,10 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
 
     std::unique_lock<std::mutex> guardLock(lock);
 
-    // The layout run can only be canceled after it starts
-    cancelLayout = false;
+    if (cancelLayout)
+    {
+        return;
+    }
 
     // Make copies of the layout objects
     const LayoutEntrySet localLayoutObjects(layoutObjects.begin(), layoutObjects.end());
@@ -1431,8 +1433,6 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
     ssBuild.flushChanges(changes, drawIDs);
 
     //wkLog("Layout of %d objects, %d clusters took %f", localLayoutObjects.size(), clusters.size(), scene->getCurrentTime() - curTime);
-
-    cancelLayout = false;
 }
 
 }

--- a/common/WhirlyGlobeLib/src/LayoutManager.cpp
+++ b/common/WhirlyGlobeLib/src/LayoutManager.cpp
@@ -22,6 +22,7 @@
 #import "SharedAttributes.h"
 #import "LinearTextBuilder.h"
 #import "WhirlyKitLog.h"
+#import "Expect.h"
 
 using namespace Eigen;
 
@@ -82,6 +83,7 @@ LayoutObjectEntry::LayoutObjectEntry(SimpleIdentity theId)
 LayoutManager::LayoutManager() :
     maxDisplayObjects(0),
     hasUpdates(false),
+    cancelLayout(false),
     showDebugBoundaries(false),
     clusterGen(nullptr),
     vecProgID(EmptyIdentity)
@@ -253,6 +255,12 @@ void LayoutManager::addClusterGenerator(PlatformThreadInfo *, ClusterGenerator *
     std::lock_guard<std::mutex> guardLock(lock);
     clusterGen = inClusterGen;
     hasUpdates = true;
+}
+
+void LayoutManager::cancelUpdate()
+{
+    std::lock_guard<std::mutex> guardLock(lock);
+    cancelLayout = true;
 }
 
 // Collection of objects we'll cluster together
@@ -514,6 +522,11 @@ bool LayoutManager::runLayoutRules(PlatformThreadInfo *threadInfo,
         auto * const obj = layoutObjRef.get();
         if (obj->obj.enable)
         {
+            if (UNLIKELY(cancelLayout))
+            {
+                break;
+            }
+
             bool use = obj->obj.state.minVis == DrawVisibleInvalid ||
                        obj->obj.state.maxVis == DrawVisibleInvalid;
             if (!use)
@@ -689,7 +702,12 @@ bool LayoutManager::runLayoutRules(PlatformThreadInfo *threadInfo,
             }
 
             // Deal with the clusters and their own overlaps
-            clusterHelper.resolveClusters();
+            clusterHelper.resolveClusters(cancelLayout);
+
+            if (UNLIKELY(cancelLayout))
+            {
+                break;
+            }
 
             // Toss the unaffected layout objects into the mix
             layoutObjs.reserve(layoutObjs.size() + clusterHelper.simpleObjects.size());
@@ -780,6 +798,11 @@ bool LayoutManager::runLayoutRules(PlatformThreadInfo *threadInfo,
         clusterGen->endLayoutObjects(threadInfo);
     }
 
+    if (UNLIKELY(cancelLayout))
+    {
+        return false;
+    }
+
 //    NSLog(@"----Starting Layout----");
 
     // Set up the overlap sampler
@@ -807,16 +830,18 @@ bool LayoutManager::runLayoutRules(PlatformThreadInfo *threadInfo,
 
     // Lay out the various objects that are active
     int numSoFar = 0;
-    for (auto container : layoutObjs)
+    for (auto &container : layoutObjs)
     {
-        bool isActive;
+        if (UNLIKELY(cancelLayout))
+        {
+            break;
+        }
+
         Point2d objOffset(0.0,0.0);
         Point2dVector objPts(4);
 
         // Start with a max objects check
-        isActive = true;
-        if (maxDisplayObjects != 0 && (numSoFar >= maxDisplayObjects))
-            isActive = false;
+        bool isActive = !(maxDisplayObjects != 0 && (numSoFar >= maxDisplayObjects));
 
         // Sort the objects by importance within their container, large to small
         std::sort(container.objs.begin(),container.objs.end(),
@@ -830,6 +855,11 @@ bool LayoutManager::runLayoutRules(PlatformThreadInfo *threadInfo,
 
         for (auto &layoutObj : container.objs)
         {
+            if (UNLIKELY(cancelLayout))
+            {
+                break;
+            }
+
             layoutObj->newEnable = false;
             layoutObj->obj.layoutModelPlaces.clear();
             layoutObj->obj.layoutPlaces.clear();
@@ -1197,37 +1227,56 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
         }
     }
 
-    // Make copies of the layout objects
     std::unique_lock<std::mutex> guardLock(lock);
-    LayoutEntrySet localLayoutObjects(layoutObjects.begin(), layoutObjects.end());
-    std::unordered_set<std::string> localOverrideUUIDs(overrideUUIDs.begin(), overrideUUIDs.end());
+
+    // The layout run can only be canceled after it starts
+    cancelLayout = false;
+
+    // Make copies of the layout objects
+    const LayoutEntrySet localLayoutObjects(layoutObjects.begin(), layoutObjects.end());
+    const std::unordered_set<std::string> localOverrideUUIDs(overrideUUIDs.begin(), overrideUUIDs.end());
 
     // Any changes made after this will require another round of layout
     hasUpdates = false;
 
     // Release the external lock to allow objects to be added and removed while we're doing the
     // layout on our copies, and replace it with a separate lock to make sure we're only run once.
-    guardLock = std::unique_lock<std::mutex>(internalLock);
+    guardLock = std::unique_lock<std::mutex>(internalLock, std::try_to_lock);
+
+    // If we couldn't acquire the lock, layout is already running on another thread.
+    // Bail out immediately rather than waiting.  Even if it finished immediately, we wouldn't
+    // want to run a layout pass on the now-obsolete copy of the layout items we have.
+    if (!guardLock.owns_lock())
+    {
+        wkLogLevel(Warn, "Layout called on multiple threads");
+        return;
+    }
 
     const TimeInterval curTime = scene->getCurrentTime();
-    //const auto t0 = std::chrono::steady_clock::now();
 
+    // Clear out any debug outlines we accumulated on the previous update
     if (!debugVecIDs.empty())
     {
         vecManage->removeVectors(debugVecIDs, changes);
         debugVecIDs.clear();
     }
 
-    std::vector<ClusterEntry> oldClusters = std::move(clusters);
-    std::vector<ClusterGenerator::ClusterClassParams> oldClusterParams = std::move(clusterParams);
-
+    const std::vector<ClusterEntry> oldClusters = std::move(clusters);
+    const std::vector<ClusterGenerator::ClusterClassParams> oldClusterParams = std::move(clusterParams);
 
     // This will recalculate the offsets and enables
     // If there were any changes, we need to regenerate
-    bool layoutChanges = runLayoutRules(threadInfo,viewState,
-                                        localLayoutObjects,
-                                        localOverrideUUIDs,
+    bool layoutChanges = runLayoutRules(threadInfo, viewState,
+                                        localLayoutObjects, localOverrideUUIDs,
                                         clusters,clusterParams,changes);
+
+    // Note: check for cancellation before accessing `clusterGen`.
+    // If shutdown has timed out, it will be invalid.
+    if (cancelLayout)
+    {
+        cancelLayout = false;
+        return;
+    }
 
     // Compare old and new clusters
     if (!layoutChanges && clusters.size() != oldClusters.size())
@@ -1271,7 +1320,7 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
         if (layoutObj->currentEnable && !layoutObj->newEnable && layoutObj->newCluster > -1)
         {
             ClusterEntry *cluster = &clusters[layoutObj->newCluster];
-            ClusterGenerator::ClusterClassParams &params = oldClusterParams[cluster->clusterParamID];
+            const auto &params = oldClusterParams[cluster->clusterParamID];
 
             // Animate from the old position to the new cluster position
             ScreenSpaceObject animObj = layoutObj->obj;     // NOLINT slicing LayoutObject to ScreenSpaceObject
@@ -1286,17 +1335,14 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
         else if (!layoutObj->currentEnable && layoutObj->newEnable && layoutObj->currentCluster > -1 && layoutObj->newCluster == -1)
         {
             // Just moved out of a cluster
-            ClusterEntry *oldCluster;
-            if (layoutObj->currentCluster < oldClusters.size())
-            {
-                oldCluster = &oldClusters[layoutObj->currentCluster];
-            }
-            else
+            if (layoutObj->currentCluster >= oldClusters.size())
             {
                 wkLogLevel(Warn,"Cluster ID mismatch");
                 continue;
             }
-            ClusterGenerator::ClusterClassParams &params = oldClusterParams[oldCluster->clusterParamID];
+
+            const ClusterEntry *oldCluster = &oldClusters[layoutObj->currentCluster];
+            const auto &params = oldClusterParams[oldCluster->clusterParamID];
 
             // Animate from the old cluster position to the new real position
             ScreenSpaceObject animObj = layoutObj->obj; // NOLINT slicing LayoutObject to ScreenSpaceObject
@@ -1336,6 +1382,12 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
         layoutObj->changed = false;
     }
 
+    if (cancelLayout)
+    {
+        cancelLayout = false;
+        return;
+    }
+
 //        NSLog(@"Got %lu clusters",clusters.size());
 
     // Add in the clusters
@@ -1344,16 +1396,12 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
         // Animate from the old cluster if there is one
         if (cluster.childOfCluster > -1)
         {
-            ClusterEntry *oldCluster;
-            if (cluster.childOfCluster < oldClusters.size())
-            {
-                oldCluster = &oldClusters[cluster.childOfCluster];
-            }
-            else
+            if (cluster.childOfCluster >= oldClusters.size())
             {
                 wkLogLevel(Warn,"Cluster ID mismatch");
                 continue;
             }
+            const ClusterEntry *oldCluster = &oldClusters[cluster.childOfCluster];
             const auto &params = oldClusterParams[oldCluster->clusterParamID];
 
             // Animate from the old cluster to the new one
@@ -1382,8 +1430,9 @@ void LayoutManager::updateLayout(PlatformThreadInfo *threadInfo,const ViewStateR
 
     ssBuild.flushChanges(changes, drawIDs);
 
-    //wkLog("Layout of %d objects, %d clusters took %f", numLayoutObjects, numClusters,
-    // std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - t0).count() / 1.0e9);
+    //wkLog("Layout of %d objects, %d clusters took %f", localLayoutObjects.size(), clusters.size(), scene->getCurrentTime() - curTime);
+
+    cancelLayout = false;
 }
 
 }

--- a/common/WhirlyGlobeLib/src/OverlapHelper.cpp
+++ b/common/WhirlyGlobeLib/src/OverlapHelper.cpp
@@ -19,6 +19,7 @@
 #import "OverlapHelper.h"
 #import "WhirlyGeometry.h"
 #import "VectorData.h"
+#import "Expect.h"
 
 using namespace Eigen;
 using namespace WhirlyKit;
@@ -284,12 +285,17 @@ void ClusterHelper::addObject(LayoutObjectEntryRef objEntry,const Point2dVector 
         addToCells(ptsMbr, newID);
 }
 
-void ClusterHelper::resolveClusters()
+void ClusterHelper::resolveClusters(volatile bool &cancel)
 {
     // Find single objects that overlap existing clusters.
     // We won't move the clusters here to keep it simpler
     for (int so=0;so<simpleObjects.size();so++)
     {
+        if (UNLIKELY(cancel))
+        {
+            return;
+        }
+
         SimpleObject *simpleObj = &simpleObjects[so];
         if (simpleObj->parentObject < 0)
         {
@@ -319,6 +325,11 @@ void ClusterHelper::resolveClusters()
     // Look for clusters that overlap one another
     for (int ci=0;ci<clusterObjects.size();ci++)
     {
+        if (UNLIKELY(cancel))
+        {
+            return;
+        }
+
         ClusterObject *clusterObj = &clusterObjects[ci];
         if (!clusterObj->children.empty())
         {

--- a/ios/library/WhirlyGlobe-MaplyComponent/WhirlyGlobeMaplyComponent.xcodeproj/project.pbxproj
+++ b/ios/library/WhirlyGlobe-MaplyComponent/WhirlyGlobeMaplyComponent.xcodeproj/project.pbxproj
@@ -993,6 +993,7 @@
 		31942FE2254B5C0A0006B499 /* maply_pb.h in Headers */ = {isa = PBXBuildFile; fileRef = 31942FC0254B5C0A0006B499 /* maply_pb.h */; };
 		31942FE7254B5C0A0006B499 /* maply_pb_decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 31942FC5254B5C0A0006B499 /* maply_pb_decode.h */; };
 		3194300A254B77F00006B499 /* vector_tile.pb.c in Sources */ = {isa = PBXBuildFile; fileRef = 31943009254B77F00006B499 /* vector_tile.pb.c */; };
+		31A2B37F26AA136A00221CFF /* Expect.h in Headers */ = {isa = PBXBuildFile; fileRef = 31A2B37E26AA136900221CFF /* Expect.h */; };
 		E56DB3D51D6B1B17007000D2 /* SLDStyleSet.h in Headers */ = {isa = PBXBuildFile; fileRef = E56DB3D41D6B1B17007000D2 /* SLDStyleSet.h */; };
 		E56E02A71E11F99500C1DD85 /* GeoJSONSource.h in Headers */ = {isa = PBXBuildFile; fileRef = E56E02A61E11F99500C1DD85 /* GeoJSONSource.h */; };
 		E5D2D6631DE67B1400E02305 /* MaplyLocationTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D2D6621DE67B1400E02305 /* MaplyLocationTracker.h */; };
@@ -2006,6 +2007,7 @@
 		31942FC0254B5C0A0006B499 /* maply_pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = maply_pb.h; sourceTree = "<group>"; };
 		31942FC5254B5C0A0006B499 /* maply_pb_decode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = maply_pb_decode.h; sourceTree = "<group>"; };
 		31943009254B77F00006B499 /* vector_tile.pb.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = vector_tile.pb.c; path = ../../../../common/WhirlyGlobeLib/src/vector_tile.pb.c; sourceTree = "<group>"; };
+		31A2B37E26AA136900221CFF /* Expect.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Expect.h; path = ../../../../common/WhirlyGlobeLib/include/Expect.h; sourceTree = "<group>"; };
 		E56DB3D41D6B1B17007000D2 /* SLDStyleSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SLDStyleSet.h; sourceTree = "<group>"; };
 		E56DB3D71D6B1B5A007000D2 /* SLDStyleSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SLDStyleSet.m; sourceTree = "<group>"; };
 		E56E02A61E11F99500C1DD85 /* GeoJSONSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeoJSONSource.h; sourceTree = "<group>"; };
@@ -2088,6 +2090,7 @@
 		2B23133121F9371F006AA344 /* util */ = {
 			isa = PBXGroup;
 			children = (
+				31A2B37E26AA136900221CFF /* Expect.h */,
 				2BD6FA63254B477F00FD8374 /* DictionaryC.h */,
 				2BB8E1BC21FBCEA400154CDC /* SharedAttributes.h */,
 				2B23133721F942D1006AA344 /* Dictionary.h */,
@@ -4095,6 +4098,7 @@
 				2BE5383B1D249A1200B60FAD /* MaplyComponentObject_private.h in Headers */,
 				2BE5384B1D249A1200B60FAD /* MaplyShape_private.h in Headers */,
 				2B82B6001E82E2490095FB14 /* JSONAllocator.h in Headers */,
+				31A2B37F26AA136A00221CFF /* Expect.h in Headers */,
 				2BE538671D249A1200B60FAD /* MaplyVectorTileMarkerStyle.h in Headers */,
 				2B82B6D91E82E24A0095FB14 /* UIImage+Stuff.h in Headers */,
 				2BC90D6622405DD200D8B606 /* Sun.h in Headers */,


### PR DESCRIPTION
A few interesting changes here.  I was able to get crashes when shutting down with a lot of layout going on (mostly due to accessing the cluster generator after it was destroyed) so I added cancellation to the layout process, and added a way to tell the compiler that it's almost always not canceled for better branch prediction on the checks.

Unfortunately, that didn't work because the layout is being done within `startOfWork`/`endOfWork`, so we couldn't even begin the shutdown process until the layout ended.  So I moved layout outside the work region, but that still didn't work because the shutdown runs on the layer thread, and so the layer shutdown still didn't run until the layout run was complete.

So I added a `preShutdown` method which is called in place of just setting the boolean shutdown field, giving the derived layer class a chance to initiate shutdown early on, and setting the layout cancellation flag from there made it work.

Testing with slow layout runs, I ran into timeouts waiting for the work item count a few times, and when looking at the stack traces I found that the layer threads were actually waiting on the lock needed for `endOfWork`.  So I converted that lock, which just protects one integer field, into an atomic value which should be much more efficient, and slowed down the polling loop a bit, from 100 to 40 Hz.