### PR TITLE
Use weak ref to the JVM object to avoid a reference cycle requiring e…

### DIFF
--- a/android/library/maply/WhirlyGlobeLib/include/MapboxVectorStyleSet_Android.h
+++ b/android/library/maply/WhirlyGlobeLib/include/MapboxVectorStyleSet_Android.h
@@ -68,7 +68,7 @@ public:
     void cleanup(JNIEnv *env);
 
 public:
-    jobject thisObj = nullptr;
+    jweak thisObj = nullptr;
     jmethodID makeLabelInfoMethod = nullptr;
     jmethodID calculateTextWidthMethod = nullptr;
     jmethodID makeCircleTextureMethod = nullptr;

--- a/common/WhirlyGlobeLib/src/DynamicTextureAtlas.cpp
+++ b/common/WhirlyGlobeLib/src/DynamicTextureAtlas.cpp
@@ -1,5 +1,4 @@
-/*
- *  DynamicTextureAtlas.mm
+/*  DynamicTextureAtlas.cpp
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 2/28/13.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "DynamicTextureAtlas.h"


### PR DESCRIPTION
…xplicit external disposal of `MapboxVectorStyleSet`.