### PR TITLE
Fix an uninitialized member causing garbage values for `QuadImageFrameLoader.curOvlLevel`.

### DIFF
--- a/common/WhirlyGlobeLib/include/QuadTileBuilder.h
+++ b/common/WhirlyGlobeLib/include/QuadTileBuilder.h
@@ -29,9 +29,34 @@ class QuadTileBuilder;
  
     This is passed to a Tile Builder Delegate when changes are being made in the Tile Builder;
   */
-class TileBuilderDelegateInfo {
-public:
-    int targetLevel;
+struct TileBuilderDelegateInfo
+{
+    TileBuilderDelegateInfo() = default;
+    TileBuilderDelegateInfo(const TileBuilderDelegateInfo&) = default;
+    TileBuilderDelegateInfo(TileBuilderDelegateInfo &&that) noexcept :
+        targetLevel(that.targetLevel),
+        loadTiles(std::move(that.loadTiles)),
+        unloadTiles(std::move(that.unloadTiles)),
+        enableTiles(std::move(that.enableTiles)),
+        disableTiles(std::move(that.disableTiles)),
+        changeTiles(std::move(that.changeTiles))
+    {
+    }
+    TileBuilderDelegateInfo& operator=(const TileBuilderDelegateInfo&) = default;
+    TileBuilderDelegateInfo& operator=(TileBuilderDelegateInfo &&that) noexcept
+    {
+        if (this != &that) {
+            targetLevel = that.targetLevel;
+            loadTiles = std::move(that.loadTiles);
+            unloadTiles = std::move(that.unloadTiles);
+            enableTiles = std::move(that.enableTiles);
+            disableTiles = std::move(that.disableTiles);
+            changeTiles = std::move(that.changeTiles);
+        }
+        return *this;
+    }
+
+    int targetLevel = -1;
     LoadedTileVec loadTiles;
     QuadTreeNew::NodeSet unloadTiles;
     LoadedTileVec enableTiles,disableTiles;

--- a/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
+++ b/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
@@ -1054,8 +1054,8 @@ void QuadImageFrameLoader::updateRenderState(ChangeSet &changes)
     // See if there's any loading happening
     bool allLoaded = true;
     for (const auto& it : tiles) {
-        auto tileID = it.first;
-        auto tile = it.second;
+        const auto &tileID = it.first;
+        const auto &tile = it.second;
         if (tileID.level == targetLevel && tile->anyFramesLoading(this)) {
             allLoaded = false;
             break;
@@ -1067,13 +1067,11 @@ void QuadImageFrameLoader::updateRenderState(ChangeSet &changes)
     if (curOvlLevel == -1) {
         curOvlLevel = targetLevel;
         if (debugMode)
-            wkLogLevel(Debug, "MaplyQuadImageLoader: Picking new overlay level %d, targetLevel = %d",curOvlLevel,targetLevel);
-    } else {
-        if (allLoaded) {
-            curOvlLevel = targetLevel;
-            if (debugMode)
-                wkLogLevel(Debug, "MaplyQuadImageLoader: Picking new overlay level %d, targetLevel = %d",curOvlLevel,targetLevel);
-        }
+            wkLogLevel(Debug, "MaplyQuadImageLoader: Picking new overlay level %d",curOvlLevel);
+    } else if (allLoaded && curOvlLevel != targetLevel) {
+        if (debugMode)
+            wkLogLevel(Debug, "MaplyQuadImageLoader: Picking new overlay level %d -> %d",curOvlLevel,targetLevel);
+        curOvlLevel = targetLevel;
     }
     
     // Work through the tiles, figuring out textures and objects
@@ -1149,7 +1147,7 @@ void QuadImageFrameLoader::updateRenderState(ChangeSet &changes)
                     }
                 }
             } else {
-                int newDrawPriority = baseDrawPriority + drawPriorityPerLevel * tileID.level;
+                const int newDrawPriority = baseDrawPriority + drawPriorityPerLevel * tileID.level;
                 for (int focusID = 0;focusID<getNumFocus();focusID++) {
                     for (const auto drawID : tile->getInstanceDrawIDs(focusID)) {
                         changes.push_back(new OnOffChangeRequest(drawID,false));


### PR DESCRIPTION
Make `TileBuilderDelegateInfo` moveable.