### PR TITLE
Fix a race condition when `releaseSamplingLayer` removed the one and …

### DIFF
--- a/android/library/maply/src/main/java/com/mousebird/maply/BaseController.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/BaseController.java
@@ -1342,7 +1342,8 @@ public abstract class BaseController implements RenderController.TaskManager, Re
 		QuadSamplingLayer theLayer = null;
 
 		for (QuadSamplingLayer layer : samplingLayers) {
-			if (layer.params.equals(params)) {
+			// Layers being shut down should already be removed, but check anyway.
+			if (layer.params.equals(params) && !layer.isShuttingDown) {
 				theLayer = layer;
 				break;
 			}
@@ -1353,7 +1354,7 @@ public abstract class BaseController implements RenderController.TaskManager, Re
 			theLayer = new QuadSamplingLayer(this,params);
 
 			// On its own layer thread
-			LayerThread layerThread = makeLayerThread(true);
+			final LayerThread layerThread = makeLayerThread(true);
 			if (layerThread == null) {
 				return null;
 			}
@@ -1380,26 +1381,31 @@ public abstract class BaseController implements RenderController.TaskManager, Re
 		if (!samplingLayers.contains(samplingLayer))
 			return;
 
-		// Do the remove client on the layer thread
+		// If we're the last client, we expect to remove the sampling layer after disconnecting,
+		// but we have to do thread transitions during which a `findSamplingLayer` call could queue
+		// up an `addClient` call, causing us to delete the layer after being connected, cancelling
+		// any activity in that new client.
+		// To prevent that, remove it from the list of available sampling layers now.
+		final int remainingClients = samplingLayer.getNumClients() - 1;
+		if (remainingClients == 0) {
+			samplingLayers.remove(samplingLayer);
+		}
+
+		// Do the remove client on the layer thread itself
 		samplingLayer.layerThread.addTask(() -> {
 			samplingLayer.removeClient(user);
 
-			// Get rid of the sampling layer too
-			if (samplingLayer.getNumClients() == 0) {
-				// But that has to be done on the main thread
-				BaseController control = samplingLayer.control.get();
-				if (control != null) {
-					Activity activity = control.getActivity();
-					Looper looper = (activity != null) ? activity.getMainLooper() : null;
-					Handler handler = new Handler((looper != null) ? looper : Looper.getMainLooper());
-					handler.post(() -> {
-						// Someone maybe started using it
-						if (samplingLayer.getNumClients() == 0) {
-							removeLayerThread(samplingLayer.layerThread);
-							samplingLayers.remove(samplingLayer);
-						}
-					});
-				}
+			// If we were the last client, switch back to the main thread to remove the layer
+			if (remainingClients == 0) {
+				newMainLooperHandler().post(() -> {
+					// It shouldn't be possible to add clients, but check one more time, just in case
+					if (samplingLayer.getNumClients() == 0) {
+						removeLayerThread(samplingLayer.layerThread);
+					} else {
+						Log.w("Maply", "Unexpected sampling layer attach");
+						samplingLayers.add(samplingLayer);
+					}
+				});
 			}
 		});
 	}


### PR DESCRIPTION
…only client and initiated removal of the layer but, before completing that process, `findSamplingLayer` found the same layer and queued up an `addClient`, which was then run after the final check for active clients.  As a result, the new client would find its sampling layer in the shutdown state and discard all fetched data.  Now the layer is removed from the list of potential layers before starting the removal process.