### PR TITLE
Add support for `findHeightToViewBounds` placing the given MBR in a specific area

### DIFF
--- a/ios/apps/AutoTester/AutoTester/testCases/FindHeightTestCase.m
+++ b/ios/apps/AutoTester/AutoTester/testCases/FindHeightTestCase.m
@@ -52,20 +52,48 @@
     [self setupWithBaseVC:(MaplyBaseViewController *)globeVC];
     [globeVC animateToPosition:MaplyCoordinateMakeWithDegrees(-98.58, 39.83) height:1.5 heading:0 time:1.0];
 
-    dispatch_after( dispatch_time(DISPATCH_TIME_NOW, 1.0 * NSEC_PER_SEC), dispatch_get_main_queue(),
-    ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 1.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
         if (self->stopped) {
             return;
         }
-        MaplyBoundingBox bbox;
-        bbox.ll = MaplyCoordinateMakeWithDegrees(7.05090689853, 47.7675500593);
-        bbox.ur = MaplyCoordinateMakeWithDegrees(8.06813647023, 49.0562323851);
+        const MaplyBoundingBox bbox = { MaplyCoordinateMakeWithDegrees(7.05090689853, 47.7675500593),
+                                        MaplyCoordinateMakeWithDegrees(8.06813647023, 49.0562323851) };
         [self addBoundingBox:bbox baseVC:globeVC];
 
+        const CGPoint margin = CGPointMake(20, 50);
+
         const MaplyCoordinate center = MaplyCoordinateMakeWithDegrees((7.05090689853+8.06813647023)/2, (47.7675500593+49.0562323851)/2);
-        const double height = [globeVC findHeightToViewBounds:bbox pos:center];
-        [globeVC animateToPosition:center height:height*1.1 heading:0 time:3.0];
+        const double height = [globeVC findHeightToViewBounds:bbox
+                                                          pos:center
+                                                      marginX:-margin.x
+                                                      marginY:-margin.y];
+        if (height > 0)
+        {
+            [globeVC animateToPosition:center height:height heading:0 time:3.0];
+        }
         NSLog(@"height = %f",height);
+        
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 4.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            if (self->stopped) {
+                return;
+            }
+            // Consider the bottom/right quarter of the screen to test offset and size
+            const CGRect wholeFrame = globeVC.view.frame;
+            const CGRect frame = CGRectIntersection(wholeFrame,
+                                    CGRectOffset(wholeFrame, wholeFrame.size.width / 2, wholeFrame.size.height / 2));
+            MaplyCoordinate newCenter = {0,0};
+            const double height = [globeVC findHeightToViewBounds:bbox
+                                                              pos:center
+                                                            frame:frame
+                                                           newPos:&newCenter
+                                                          marginX:-margin.x
+                                                          marginY:-margin.y];
+            if (height > 0)
+            {
+                [globeVC animateToPosition:newCenter height:height heading:0 time:1.0];
+            }
+            NSLog(@"center = %f/%f height = %f", 180*newCenter.y/M_PI, 180*newCenter.x/M_PI, height);
+        });
     });
 }
 
@@ -77,20 +105,50 @@
     [self setupWithBaseVC:(MaplyBaseViewController *)mapVC];
     [mapVC animateToPosition:MaplyCoordinateMakeWithDegrees(-98.58, 39.83) height:1.5 time:1.0];
 
-    dispatch_after( dispatch_time(DISPATCH_TIME_NOW, 1.0 * NSEC_PER_SEC), dispatch_get_main_queue(),
-    ^{
+    dispatch_after( dispatch_time(DISPATCH_TIME_NOW, 1.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
         if (self->stopped) {
             return;
         }
-        MaplyBoundingBox bbox;
-        bbox.ll = MaplyCoordinateMakeWithDegrees(7.05090689853, 47.7675500593);
-        bbox.ur = MaplyCoordinateMakeWithDegrees(8.06813647023, 49.0562323851);
+        MaplyBoundingBox bbox = { MaplyCoordinateMakeWithDegrees(7.05090689853, 47.7675500593),
+                                  MaplyCoordinateMakeWithDegrees(8.06813647023, 49.0562323851) };
         [self addBoundingBox:bbox baseVC:mapVC];
-        
+
+        const CGPoint margin = CGPointMake(20, 50);
+
         const MaplyCoordinate center = MaplyCoordinateMakeWithDegrees((7.05090689853+8.06813647023)/2, (47.7675500593+49.0562323851)/2);
-        const double height = [mapVC findHeightToViewBounds:bbox pos:center marginX:20.0 marginY:100.0];
-        [mapVC animateToPosition:center height:height heading:mapVC.heading time:3.0];
+        const double height = [mapVC findHeightToViewBounds:bbox
+                                                        pos:center
+                                                    marginX:-margin.x
+                                                    marginY:-margin.y];
+        if (height > 0)
+        {
+            [mapVC animateToPosition:center height:height heading:mapVC.heading time:3.0];
+        }
         NSLog(@"height = %f",height);
+        
+        // Then, repeat but fit it into just part of the view
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 4.0 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            if (self->stopped) {
+                return;
+            }
+            // Consider the bottom/right quarter of the screen to test offset and size
+            const CGRect wholeFrame = mapVC.view.frame;
+            const CGRect frame = CGRectIntersection(wholeFrame,
+                                    CGRectOffset(wholeFrame, wholeFrame.size.width / 2,
+                                                             wholeFrame.size.height / 2));
+            MaplyCoordinate newCenter = {0,0};
+            const double height = [mapVC findHeightToViewBounds:bbox
+                                                            pos:center
+                                                          frame:frame
+                                                         newPos:&newCenter
+                                                        marginX:-margin.x
+                                                        marginY:-margin.y];
+            if (height > 0)
+            {
+                [mapVC animateToPosition:newCenter height:height heading:mapVC.heading time:1.0];
+            }
+            NSLog(@"center = %f/%f height = %f", 180*newCenter.y/M_PI, 180*newCenter.x/M_PI, height);
+        });
     });
 }
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/control/MaplyViewController.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/control/MaplyViewController.h
@@ -1,9 +1,8 @@
-/*
- *  MaplyViewController.h
+/*  MaplyViewController.h
  *  MaplyComponent
  *
  *  Created by Steve Gifford on 9/6/12.
- *  Copyright 2012-2019 mousebird consulting
+ *  Copyright 2012-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <UIKit/UIKit.h>
@@ -586,24 +584,48 @@ typedef NS_ENUM(NSInteger, MaplyMapType) {
     
     @param pos Where the view will be looking.
   */
-- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox pos:(MaplyCoordinate)pos;
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos;
 
 /** 
     Find a height that shows the given bounding box.
- 
     This method will search for a height that shows the given bounding box within the view.  The search is inefficient, so don't call this a lot.
- 
-    This version takes a margin to add around the outside of the area.
+
+    This version takes a margin to add around the outside of the area.  Positive margins increase the screen area considered, making the
+    given area larger.  Negative margins make the specified area smaller.
  
     @param bbox The bounding box (in radians) we're trying to view.
- 
     @param pos Where the view will be looking.
- 
     @param marginX Horizontal boundary around the area
- 
     @param marginY Vertical boundary around the area
  */
-- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox pos:(MaplyCoordinate)pos marginX:(double)marginX marginY:(double)marginY;
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                        marginX:(double)marginX
+                        marginY:(double)marginY;
+
+/**
+    Find a height that shows the given bounding box.
+    This method will search for a height that shows the given bounding box within the view.  The search is inefficient, so don't call this a lot.
+
+    This version takes a margin to add around the outside of the area.  Positive margins increase the screen area considered, making the
+    given area larger.  Negative margins make the specified area smaller.
+
+    This version attempts to place the given bounds within a rectangle other than the whole view frame.
+
+    @param bbox The bounding box (in radians) we're trying to view.
+    @param pos Where the view will be looking.
+    @param frame The screen area to consider.
+    @param newPos (out,optional) The center location needed to place \c pos at the center of \c frame
+    @param marginX Horizontal boundary around the area
+    @param marginY Vertical boundary around the area
+ */
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                          frame:(CGRect)frame
+                         newPos:(MaplyCoordinate *_Nullable)newPos
+                        marginX:(double)marginX
+                        marginY:(double)marginY;
 
 /**
  

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/control/WhirlyGlobeViewController.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/control/WhirlyGlobeViewController.h
@@ -719,6 +719,47 @@
 - (float)findHeightToViewBounds:(MaplyBoundingBox)bbox pos:(MaplyCoordinate)pos;
 
 /**
+    Find a height that shows the given bounding box.
+    This method will search for a height that shows the given bounding box within the view.  The search is inefficient, so don't call this a lot.
+
+    This version takes a margin to add around the outside of the area.  Positive margins increase the screen area considered, making the
+    given area larger.  Negative margins make the specified area smaller.
+
+    @param bbox The bounding box (in radians) we're trying to view.
+    @param pos Where the view will be looking.
+    @param marginX Horizontal boundary around the area
+    @param marginY Vertical boundary around the area
+ */
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                        marginX:(double)marginX
+                        marginY:(double)marginY;
+
+/**
+    Find a height that shows the given bounding box.
+    This method will search for a height that shows the given bounding box within the view.  The search is inefficient, so don't call this a lot.
+
+    This version takes a margin to add around the outside of the area.  Positive margins increase the screen area considered, making the
+    given area larger.  Negative margins make the specified area smaller.
+ 
+    This version attempts to place the given bounds within a rectangle other than the whole view frame.
+    Note that this doesn't work well when the bounds are very large.
+
+    @param bbox The bounding box (in radians) we're trying to view.
+    @param pos Where the view will be looking.
+    @param frame The screen area to consider.
+    @param newPos (out,optional) The center location needed to place \c pos at the center of \c frame
+    @param marginX Horizontal boundary around the area
+    @param marginY Vertical boundary around the area
+ */
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                          frame:(CGRect)frame
+                         newPos:(MaplyCoordinate *_Nullable)newPos
+                        marginX:(double)marginX
+                        marginY:(double)marginY;
+
+/**
  
     Return the extents of the current view.
  

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyViewController_private.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyViewController_private.h
@@ -1,9 +1,8 @@
-/*
- *  MaplyViewController_private.h
+/*  MaplyViewController_private.h
  *  MaplyComponent
  *
  *  Created by Steve Gifford on 12/14/12.
- *  Copyright 2012-2019 mousebird consulting
+ *  Copyright 2012-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "MaplyViewController.h"

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/private/WhirlyGlobeViewController_private.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/private/WhirlyGlobeViewController_private.h
@@ -1,9 +1,8 @@
-/*
- *  WhirlyGlobeViewController_private.h
+/*  WhirlyGlobeViewController_private.h
  *  WhirlyGlobeComponent
  *
  *  Created by Steve Gifford on 10/26/12.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <UIKit/UIKit.h>

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyViewController.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyViewController.mm
@@ -1,9 +1,8 @@
-/*
- *  MaplyViewController.mm
+/*  MaplyViewController.mm
  *  MaplyComponent
  *
  *  Created by Steve Gifford on 9/6/12.
- *  Copyright 2012-2019 mousebird consulting
+ *  Copyright 2012-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <WhirlyGlobe_iOS.h>
@@ -1261,23 +1259,67 @@ struct MaplyViewControllerAnimationWrapper : public Maply::MapViewAnimationDeleg
 }
 
 // See if the given bounding box is all on screen
-- (bool)checkCoverage:(const Mbr &)mbr mapView:(Maply::MapView *)theView height:(float)height margin:(const Point2d &)margin
+- (bool)checkCoverage:(const Mbr &)mbr
+              mapView:(Maply::MapView *)theView
+                  loc:(MaplyCoordinate)loc
+               height:(float)height
+                frame:(CGRect)frame
+               newLoc:(MaplyCoordinate *)newLoc
+               margin:(const Point2d &)margin
 {
-    // Center the bound
-    const Point3d localMid = mapView->coordAdapter->getCoordSystem()->geographicToLocal(mbr.mid().cast<double>());
+    if (frame.size.width == 0 || frame.size.height == 0)
+    {
+        return false;
+    }
+    if (newLoc)
+    {
+        *newLoc = loc;
+    }
+
+    const auto &coordAdapter = mapView->coordAdapter;
+    const auto *coordSys = coordAdapter->getCoordSystem();
+
+    // Center the given location
+    Point3d localMid = coordSys->geographicToLocal(Point2d(loc.x, loc.y));
     theView->setLoc(Point3d(localMid.x(),localMid.y(),height),false);
+
+    // If they want to center in an area other than the whole view frame, we need to work out
+    // what center point will place the given location at the center of the given view frame.
+    const auto screenCenter = CGPointMake(CGRectGetMidX(self.view.frame), CGRectGetMidY(self.view.frame));
+    const auto frameCenter = CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame));
+    const auto offset = CGPointMake(frameCenter.x - screenCenter.x, frameCenter.y - screenCenter.y);
+    if (offset.x * offset.y != 0)
+    {
+        const auto invCenter = CGPointMake(screenCenter.x - offset.x,screenCenter.y - offset.y);
+        MaplyCoordinate invGeo = {0,0};
+        if (![self geoFromScreenPoint:invCenter view:theView geo:&invGeo])
+        {
+            return false;
+        }
+
+        // Place the given location at the center of the given frame
+        localMid = coordSys->geographicToLocal(Point2d(invGeo.x, invGeo.y));
+        theView->setLoc(Point3d(localMid.x(), localMid.y(), height), false);
+        
+        if (newLoc)
+        {
+            *newLoc = invGeo;
+        }
+    }
 
     // Get the corners
     Point2fVector pts;
     mbr.asPoints(pts);
 
-    // Check each one
-    const CGRect &frame = self.view.frame;
+    // Check if each corner is within the given frame in this view
     for (const auto &pt : pts)
     {
         const CGPoint screenPt = [self screenPointFromGeo:{pt.x(),pt.y()} mapView:theView];
-        if (screenPt.x < -margin.x() || screenPt.x > frame.size.width + margin.x() ||
-            screenPt.y < -margin.y() || screenPt.y > frame.size.height + margin.y())
+        if (!std::isfinite(screenPt.y) ||
+            screenPt.x < frame.origin.x - margin.x() ||
+            screenPt.y < frame.origin.y - margin.y() ||
+            screenPt.x > frame.origin.x + frame.size.width + margin.x() ||
+            screenPt.y > frame.origin.y + frame.size.height + margin.y())
         {
             return false;
         }
@@ -1285,32 +1327,53 @@ struct MaplyViewControllerAnimationWrapper : public Maply::MapViewAnimationDeleg
     return true;
 }
 
-- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox pos:(MaplyCoordinate)pos
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
 {
-    return [self findHeightToViewBounds:bbox pos:pos marginX:0 marginY:0];
+    return [self findHeightToViewBounds:bbox
+                                    pos:pos
+                                marginX:0
+                                marginY:0];
 }
 
-- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox pos:(MaplyCoordinate)pos marginX:(double)marginX marginY:(double)marginY
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                        marginX:(double)marginX
+                        marginY:(double)marginY
 {
-    const Point2d margin(marginX,marginY);
-    
+    return [self findHeightToViewBounds:bbox
+                                    pos:pos
+                                  frame:self.view.frame
+                                 newPos:nil
+                                marginX:marginX
+                                marginY:marginY];
+}
+
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                          frame:(CGRect)frame
+                         newPos:(MaplyCoordinate *)newPos
+                        marginX:(double)marginX
+                        marginY:(double)marginY
+{
     if (!mapView)
     {
         return 0;
     }
+
+    // checkCoverage won't work if the frame size isn't set
+    if (frame.size.height * frame.size.width == 0)
+    {
+        return 0;
+    }
+
     Maply::MapView tempMapView(*mapView);
 
     // Center the temporary view on the new center point at the current height
     const Point3d oldLoc = tempMapView.getLoc();
-    Point3d newLoc = Point3d(pos.x,pos.y,oldLoc.z());
-    if (_coordSys)
-    {
-        newLoc = _coordSys->coordSystem->geographicToLocal3d(GeoCoord(pos.x,pos.y));
-        newLoc.z() = oldLoc.z();
-    }
-    tempMapView.setLoc(newLoc, false);
 
-    const Mbr mbr(Point2f(bbox.ll.x,bbox.ll.y),Point2f(bbox.ur.x,bbox.ur.y));
+    const Mbr mbr { { bbox.ll.x, bbox.ll.y }, { bbox.ur.x, bbox.ur.y } };
+    const Point2d margin(marginX,marginY);
 
     float minHeight = tempMapView.minHeightAboveSurface();
     float maxHeight = tempMapView.maxHeightAboveSurface();
@@ -1321,37 +1384,45 @@ struct MaplyViewControllerAnimationWrapper : public Maply::MapViewAnimationDeleg
     }
     
     // Check that we can at least see it
-    bool minOnScreen = [self checkCoverage:mbr mapView:&tempMapView height:minHeight margin:margin];
-    bool maxOnScreen = [self checkCoverage:mbr mapView:&tempMapView height:maxHeight margin:margin];
+    MaplyCoordinate minPos, maxPos;
+    const bool minOnScreen = [self checkCoverage:mbr mapView:&tempMapView loc:pos height:minHeight
+                                           frame:frame newLoc:&minPos margin:margin];
+    const bool maxOnScreen = [self checkCoverage:mbr mapView:&tempMapView loc:pos height:maxHeight
+                                           frame:frame newLoc:&maxPos margin:margin];
     if (!minOnScreen && !maxOnScreen)
     {
-        tempMapView.setLoc(oldLoc,false);
-        return oldLoc.z();
-    } else if (minOnScreen) {
-        // already fits at min zoom
-        maxHeight = minHeight;
-    } else {
-        // Now for the binary search
-        float minRange = 1e-5;
-        do
+        if (newPos)
         {
-            float midHeight = (minHeight + maxHeight)/2.0;
-            bool midOnScreen = [self checkCoverage:mbr mapView:&tempMapView height:midHeight margin:margin];
-        
-            if (!minOnScreen && midOnScreen)
-            {
-                maxHeight = midHeight;
-                maxOnScreen = YES;
-            } else if (!midOnScreen && maxOnScreen) {
-                minHeight = midHeight;
-                minOnScreen = NO;
-            } else {
-                // Not expecting this
-                break;
-            }
-        } while (maxHeight-minHeight > minRange);
+            *newPos = pos;
+        }
+        return oldLoc.z();
     }
-    
+    else if (minOnScreen)
+    {
+        // already fits at min zoom
+        if (newPos)
+        {
+            *newPos = minPos;
+        }
+        return minHeight;
+    }
+
+    // minHeight is out but maxHeight works.
+    // Binary search to find the lowest height that still works.
+    constexpr float minRange = 1e-5;
+    while (maxHeight - minHeight > minRange)
+    {
+        const float midHeight = (minHeight + maxHeight)/2.0;
+        if ([self checkCoverage:mbr mapView:&tempMapView loc:pos height:midHeight
+                         frame:frame newLoc:newPos margin:margin])
+        {
+            maxHeight = midHeight;
+        }
+        else
+        {
+            minHeight = midHeight;
+        }
+    }
     return maxHeight;
 }
 
@@ -1511,23 +1582,45 @@ struct MaplyViewControllerAnimationWrapper : public Maply::MapViewAnimationDeleg
     }
 }
 
-- (MaplyCoordinate)geoFromScreenPoint:(CGPoint)point {
-      Point3d hit;
-    SceneRenderer *sceneRender = wrapView.renderer;
-    Eigen::Matrix4d theTransform = mapView->calcFullMatrix();
-    auto frameSizeScaled = sceneRender->getFramebufferSizeScaled();
-    Point2f point2f(point.x,point.y);
-    if (mapView->pointOnPlaneFromScreen(point2f, &theTransform, frameSizeScaled, &hit, true))
+- (MaplyCoordinate)geoFromScreenPoint:(CGPoint)point
+{
+    return [self geoFromScreenPoint:point view:mapView.get()];
+}
+
+- (MaplyCoordinate)geoFromScreenPoint:(CGPoint)point view:(MapView*)view
+{
+    MaplyCoordinate geo = {0,0};
+    [self geoFromScreenPoint:point view:view geo:&geo];
+    return geo;
+}
+
+- (bool)geoFromScreenPoint:(CGPoint)point geo:(MaplyCoordinate*)geo
+{
+    return [self geoFromScreenPoint:point view:mapView.get() geo:geo];
+}
+
+- (bool)geoFromScreenPoint:(CGPoint)point view:(MapView*)view geo:(MaplyCoordinate*)geo
+{
+    if (view)
     {
-        Point3d localPt = coordAdapter->displayToLocal(hit);
-        GeoCoord coord = coordAdapter->getCoordSystem()->localToGeographic(localPt);
-        MaplyCoordinate maplyCoord;
-        maplyCoord.x = coord.x();
-        maplyCoord.y  = coord.y();
-        return maplyCoord;
-    } else {
-        return MaplyCoordinateMakeWithDegrees(0, 0);
+        SceneRenderer *sceneRender = wrapView.renderer;
+        Eigen::Matrix4d theTransform = view->calcFullMatrix();
+        const auto frameSizeScaled = sceneRender->getFramebufferSizeScaled();
+
+        Point2f point2f(point.x,point.y);
+        Point3d hit;
+        if (view->pointOnPlaneFromScreen(point2f, &theTransform, frameSizeScaled, &hit, true))
+        {
+            if (geo)
+            {
+                const Point3d localPt = coordAdapter->displayToLocal(hit);
+                const GeoCoord coord = coordAdapter->getCoordSystem()->localToGeographic(localPt);
+                *geo = {coord.x(), coord.y()};
+            }
+            return true;
+        }
     }
+    return false;
 }
 
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/WhirlyGlobeViewController.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/WhirlyGlobeViewController.mm
@@ -1,9 +1,8 @@
-/*
- *  WhirlyGlobeViewController.mm
+/*  WhirlyGlobeViewController.mm
  *  WhirlyGlobeComponent
  *
  *  Created by Steve Gifford on 7/21/12.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <WhirlyGlobe_iOS.h>
@@ -1336,22 +1334,83 @@ struct WhirlyGlobeViewWrapper : public WhirlyGlobe::GlobeViewAnimationDelegate, 
     [self handleStopMoving:userMotion];
 }
 
-// See if the given bounding box is all on sreen
-- (bool)checkCoverage:(Mbr &)mbr globeView:(WhirlyGlobe::GlobeView *)theView height:(float)height
+// See if the given bounding box is all on screen
+- (bool)checkCoverage:(const Mbr &)mbr
+            globeView:(WhirlyGlobe::GlobeView *)theView
+                  loc:(MaplyCoordinate)loc
+               height:(float)height
+                frame:(CGRect)frame
+               newLoc:(MaplyCoordinate *)newLoc
 {
+    return [self checkCoverage:mbr
+                     globeView:theView
+                           loc:loc
+                        height:height
+                         frame:frame
+                        newLoc:newLoc
+                        margin:{0.0,0.0}];
+}
+
+- (bool)checkCoverage:(const Mbr &)mbr
+            globeView:(WhirlyGlobe::GlobeView *)theView
+                  loc:(MaplyCoordinate)loc
+               height:(float)height
+                frame:(CGRect)frame
+               newLoc:(MaplyCoordinate *)newLoc
+               margin:(const Point2d &)margin
+{
+    if (!theView || frame.size.width * frame.size.height == 0)
+    {
+        return false;
+    }
+    if (newLoc)
+    {
+        *newLoc = loc;
+    }
+
+    // Center the given location
+    Eigen::Quaterniond newRotQuat = theView->makeRotationToGeoCoord(GeoCoord(loc.x,loc.y), true);
+    theView->setRotQuat(newRotQuat,false);
     theView->setHeightAboveGlobe(height, false);
+
+    // If they want to center in an area other than the whole view frame, we need to work out
+    // what center point will place the given location at the center of the given view frame.
+    const auto screenCenter = CGPointMake(CGRectGetMidX(self.view.frame), CGRectGetMidY(self.view.frame));
+    const auto frameCenter = CGPointMake(CGRectGetMidX(frame), CGRectGetMidY(frame));
+    const auto offset = CGPointMake(frameCenter.x - screenCenter.x, frameCenter.y - screenCenter.y);
+    if (offset.x * offset.y != 0)
+    {
+        const auto invCenter = CGPointMake(screenCenter.x - offset.x, screenCenter.y - offset.y);
+        MaplyCoordinate invGeo = {0,0};
+        if (![self geoPointFromScreen:invCenter theView:theView geoCoord:&invGeo])
+        {
+            return false;
+        }
+
+        // Place the given location at the center of the given frame
+        newRotQuat = theView->makeRotationToGeoCoord(Point2d(invGeo.x,invGeo.y), true);
+        theView->setRotQuat(newRotQuat,false);
+
+        if (newLoc)
+        {
+            *newLoc = invGeo;
+        }
+    }
 
     Point2fVector pts;
     mbr.asPoints(pts);
-    CGRect frame = self.view.frame;
-    for (unsigned int ii=0;ii<pts.size();ii++)
+
+    for (const auto &pt : pts)
     {
-        Point2f pt = pts[ii];
-        MaplyCoordinate geoCoord;
-        geoCoord.x = pt.x();  geoCoord.y = pt.y();
-        CGPoint screenPt = [self pointOnScreenFromGeo:geoCoord globeView:theView];
-        if (screenPt.x < 0 || screenPt.y < 0 || screenPt.x > frame.size.width || screenPt.y > frame.size.height)
+        const CGPoint screenPt = [self pointOnScreenFromGeo:{pt.x(), pt.y()} globeView:theView];
+        if (!std::isfinite(screenPt.y) ||
+            screenPt.x < frame.origin.x - margin.x() ||
+            screenPt.y < frame.origin.y - margin.y() ||
+            screenPt.x > frame.origin.x + frame.size.width + margin.x() ||
+            screenPt.y > frame.origin.y + frame.size.height + margin.y())
+        {
             return false;
+        }
     }
     
     return true;
@@ -1359,17 +1418,49 @@ struct WhirlyGlobeViewWrapper : public WhirlyGlobe::GlobeViewAnimationDelegate, 
 
 - (float)findHeightToViewBounds:(MaplyBoundingBox)bbox pos:(MaplyCoordinate)pos
 {
-    if (!globeView) {
+    return [self findHeightToViewBounds:bbox pos:pos marginX:0 marginY:0];
+}
+
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                        marginX:(double)marginX
+                        marginY:(double)marginY
+{
+    return [self findHeightToViewBounds:bbox
+                                    pos:pos
+                                  frame:self.view.frame
+                                 newPos:nil
+                                marginX:marginX
+                                marginY:marginY];
+}
+
+- (float)findHeightToViewBounds:(MaplyBoundingBox)bbox
+                            pos:(MaplyCoordinate)pos
+                          frame:(CGRect)frame
+                         newPos:(MaplyCoordinate *)newPos
+                        marginX:(double)marginX
+                        marginY:(double)marginY
+{
+    if (!globeView)
+    {
         return 0;
     }
-    GlobeView tempGlobe(*globeView);
-    
-    float oldHeight = globeView->getHeightAboveGlobe();
-    Eigen::Quaterniond newRotQuat = tempGlobe.makeRotationToGeoCoord(GeoCoord(pos.x,pos.y), true);
-    tempGlobe.setRotQuat(newRotQuat,false);
 
-    Mbr mbr(Point2f(bbox.ll.x,bbox.ll.y),Point2f(bbox.ur.x,bbox.ur.y));
-    
+    // checkCoverage won't work if the frame size isn't set
+    if (frame.size.width * frame.size.height == 0)
+    {
+        return 0;
+    }
+
+    GlobeView tempGlobe(*globeView);
+
+    const float oldHeight = globeView->getHeightAboveGlobe();
+    //const Eigen::Quaterniond newRotQuat = tempGlobe.makeRotationToGeoCoord(GeoCoord(pos.x,pos.y), true);
+    //tempGlobe.setRotQuat(newRotQuat,false);
+
+    const Mbr mbr({ bbox.ll.x, bbox.ll.y }, { bbox.ur.x, bbox.ur.y });
+    const Point2d margin(marginX, marginY);
+
     double minHeight = tempGlobe.minHeightAboveGlobe();
     double maxHeight = tempGlobe.maxHeightAboveGlobe();
     if (pinchDelegate)
@@ -1379,39 +1470,49 @@ struct WhirlyGlobeViewWrapper : public WhirlyGlobe::GlobeViewAnimationDelegate, 
     }
 
     // Check that we can at least see it
-    bool minOnScreen = [self checkCoverage:mbr globeView:&tempGlobe height:minHeight];
-    bool maxOnScreen = [self checkCoverage:mbr globeView:&tempGlobe height:maxHeight];
-    if (!minOnScreen && !maxOnScreen)
+    MaplyCoordinate minPos, maxPos;
+    const bool minOnScreen = [self checkCoverage:mbr globeView:&tempGlobe loc:pos height:minHeight
+                                           frame:frame newLoc:&minPos margin:margin];
+          bool maxOnScreen = [self checkCoverage:mbr globeView:&tempGlobe loc:pos height:maxHeight
+                                           frame:frame newLoc:&maxPos margin:margin];
+
+    // If there's a frame offset, max height will often
+    // fail, so we need to search both directions.
+    if (!minOnScreen && !maxOnScreen && !newPos)
     {
-        tempGlobe.setHeightAboveGlobe(oldHeight,false);
+        if (newPos)
+        {
+            *newPos = pos;
+        }
         return oldHeight;
     }
-    
-    // Now for the binary search
-    float minRange = 1e-5;
-    do
+    else if (minOnScreen)
     {
-        float midHeight = (minHeight + maxHeight)/2.0;
-        bool midOnScreen = [self checkCoverage:mbr globeView:&tempGlobe height:midHeight];
-        
-        if (!minOnScreen && midOnScreen)
+        if (newPos)
+        {
+            *newPos = minPos;
+        }
+        return minHeight;
+    }
+
+    // minHeight is out but maxHeight works.
+    // Binary search to find the lowest height that still works.
+    constexpr float minRange = 1e-5;
+    while (maxHeight - minHeight > minRange)
+    {
+        const float midHeight = (minHeight + maxHeight)/2.0;
+        if ([self checkCoverage:mbr globeView:&tempGlobe loc:pos height:midHeight
+                          frame:frame newLoc:newPos margin:margin])
         {
             maxHeight = midHeight;
-            maxOnScreen = midOnScreen;
-        } else if (!midOnScreen && maxOnScreen)
-        {
-            minHeight = midHeight;
-            minOnScreen = midOnScreen;
-        } else {
-            // Not expecting this
-            break;
+            maxOnScreen = true;
         }
-        
-        if (maxHeight-minHeight < minRange)
-            break;
-    } while (true);
-    
-    return maxHeight;
+        else
+        {
+            (maxOnScreen ? minHeight : maxHeight) = midHeight;
+        }
+    }
+    return maxOnScreen ? maxHeight : 0.0;
 }
 
 - (CGPoint)pointOnScreenFromGeo:(MaplyCoordinate)geoCoord
@@ -1471,21 +1572,35 @@ struct WhirlyGlobeViewWrapper : public WhirlyGlobe::GlobeViewAnimationDelegate, 
 
 - (bool)geoPointFromScreen:(CGPoint)screenPt geoCoord:(MaplyCoordinate *)retCoord
 {
-    if (!renderControl)
+    return [self geoPointFromScreen:screenPt theView:globeView.get() geoCoord:retCoord];
+}
+
+- (bool)geoPointFromScreen:(CGPoint)screenPt
+                   theView:(WhirlyGlobe::GlobeView * __nonnull)theView
+                  geoCoord:(MaplyCoordinate * __nonnull)retCoord
+{
+    if (!renderControl || !theView)
+    {
         return false;
-    
+    }
+
+    const auto *coordAdapter = theView->coordAdapter;
+    const auto *coordSys = coordAdapter->getCoordSystem();
+    const auto frameSize = renderControl->sceneRenderer->getFramebufferSizeScaled();
+
 	Point3d hit;
     Point2f screenPt2f(screenPt.x,screenPt.y);
-	Eigen::Matrix4d theTransform = globeView->calcFullMatrix();
-    if (globeView->pointOnSphereFromScreen(screenPt2f, theTransform, renderControl->sceneRenderer->getFramebufferSizeScaled(), hit, true))
+	Eigen::Matrix4d theTransform = theView->calcFullMatrix();
+    if (theView->pointOnSphereFromScreen(screenPt2f, theTransform, frameSize, hit, true))
     {
-        GeoCoord geoCoord = renderControl->visualView->coordAdapter->getCoordSystem()->localToGeographic(renderControl->visualView->coordAdapter->displayToLocal(hit));
-        retCoord->x = geoCoord.x();
-        retCoord->y = geoCoord.y();
-        
+        if (retCoord)
+        {
+            const GeoCoord geoCoord = coordSys->localToGeographic(coordAdapter->displayToLocal(hit));
+            *retCoord = { geoCoord.x(), geoCoord.y() };
+        }
         return true;
-	} else
-        return false;
+	}
+    return false;
 }
 
 - (nullable NSValue *)geoPointFromScreen:(CGPoint)screenPt


### PR DESCRIPTION
Pretty straightforward: center the target area, find the location of the opposite of the offset to the desired view bounds, and do the regular `findHeight` from there.

That offset often puts us off the globe at max height, so we have to handle binary searching both directions there.

This also simplifies the binary searches to match the Java side.