### PR TITLE
Make optional the automatic closing of areal features passed to `addVectors` (without fill) or `addWideVectors`

### DIFF
--- a/common/WhirlyGlobeLib/include/BaseInfo.h
+++ b/common/WhirlyGlobeLib/include/BaseInfo.h
@@ -90,9 +90,8 @@ typedef std::shared_ptr<ColorExpressionInfo> ColorExpressionInfoRef;
 
 /** Object use as the base for parsing description dictionaries.
  */
-class BaseInfo
+struct BaseInfo
 {
-public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 
     BaseInfo();
@@ -100,7 +99,7 @@ public:
     BaseInfo(const Dictionary &dict);
     
     // Convert contents to a string for debugging
-    virtual std::string toString();
+    virtual std::string toString() const;
     
     /// Set the various parameters on a basic drawable
     void setupBasicDrawable(BasicDrawableBuilder *drawBuild) const;

--- a/common/WhirlyGlobeLib/include/GeometryManager.h
+++ b/common/WhirlyGlobeLib/include/GeometryManager.h
@@ -30,11 +30,12 @@ typedef enum {GeometryBBoxSingle,GeometryBBoxTriangle,GeometryBBoxNone} Geometry
 // Used to pass geometry around internally
 struct GeometryInfo : public BaseInfo
 {
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
-    
     GeometryInfo() = default;
     GeometryInfo(const Dictionary &);
     virtual ~GeometryInfo() = default;
+
+    // Convert contents to a string for debugging
+    virtual std::string toString() const override { return BaseInfo::toString() + " +GeomInfo..."; }
 
     bool colorOverride = false;
     RGBAColor color = RGBAColor::white();

--- a/common/WhirlyGlobeLib/include/LabelRenderer.h
+++ b/common/WhirlyGlobeLib/include/LabelRenderer.h
@@ -76,6 +76,9 @@ public:
     LabelInfo(const Dictionary &dict,bool screenObject);
     virtual ~LabelInfo() = default;
 
+    // Convert contents to a string for debugging
+    virtual std::string toString() const override { return BaseInfo::toString() + " +LabelInfo..."; }
+
     bool hasTextColor = false;
     RGBAColor textColor = RGBAColor::white();
     RGBAColor backColor = RGBAColor::clear();

--- a/common/WhirlyGlobeLib/include/MarkerManager.h
+++ b/common/WhirlyGlobeLib/include/MarkerManager.h
@@ -62,12 +62,14 @@ public:
 typedef std::set<MarkerSceneRep *,IdentifiableSorter> MarkerSceneRepSet;
 
 // Used to pass marker information between threads
-class MarkerInfo : public BaseInfo
+struct MarkerInfo : public BaseInfo
 {
-public:
     MarkerInfo(bool screenObject);
     MarkerInfo(const Dictionary &,bool screenObject);
     virtual ~MarkerInfo() = default;
+
+    // Convert contents to a string for debugging
+    virtual std::string toString() const { return BaseInfo::toString() + " + MarkerInfo..."; }
 
     RGBAColor color;
     bool screenObject;

--- a/common/WhirlyGlobeLib/include/ShapeDrawableBuilder.h
+++ b/common/WhirlyGlobeLib/include/ShapeDrawableBuilder.h
@@ -1,9 +1,8 @@
-/*
- *  ShapeDrawableBuilder.h
+/*  ShapeDrawableBuilder.h
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 9/28/11.
- *  Copyright 2011-2019 mousebird consulting.
+ *  Copyright 2011-2021 mousebird consulting.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "Identifiable.h"
@@ -30,21 +28,20 @@ namespace WhirlyKit
 
 /// Used to pass shape info between the shape layer and the drawable builder
 ///  and within the threads of the shape layer
-class ShapeInfo : public BaseInfo
+struct ShapeInfo : public BaseInfo
 {
-public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
-    
     ShapeInfo();
     ShapeInfo(const Dictionary &);
     virtual ~ShapeInfo() = default;
 
-public:
-    RGBAColor color;
-    float lineWidth;
-    bool insideOut;
-    bool hasCenter;
-    WhirlyKit::Point3d center;
+    // Convert contents to a string for debugging
+    virtual std::string toString() const { return BaseInfo::toString() + " +ShapeInfo..."; }
+
+    RGBAColor color = RGBAColor::white();
+    float lineWidth = 1.0f;
+    bool insideOut = false;
+    bool hasCenter = false;
+    WhirlyKit::Point3d center = { 0, 0, 0 };
 };
 typedef std::shared_ptr<ShapeInfo> ShapeInfoRef;
 

--- a/common/WhirlyGlobeLib/include/SharedAttributes.h
+++ b/common/WhirlyGlobeLib/include/SharedAttributes.h
@@ -1,5 +1,4 @@
-/*
- *  SharedAttributes
+/*  SharedAttributes
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 9/19/12.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 /// Wrapper for string (Objective-C vs. other)
@@ -235,6 +233,9 @@
 /// Basic or performance mode for wide vectors
 #define MaplyWideVecImpl WKString("widevecimplementation")
 
+/// Default/old mode for wide vectors
+#define MaplyWideVecImplDefault WKString("widevecdefault")
+
 /// Performance mode for wide vectors
 #define MaplyWideVecImplPerf WKString("widevecperformance")
 
@@ -280,6 +281,9 @@
 
 /// Offset to left (negative) or right (positive) of the centerline
 #define MaplyWideVecOffset WKString("vecOffset")
+
+/// Close any un-closed areal features when drawing lines for them
+#define MaplyVecCloseAreals WKString("vecCloseAreals")
 
 /// If set we'll break up a vector feature to the given epsilon on a globe surface
 #define MaplySubdivEpsilon WKString("subdivisionepsilon")

--- a/common/WhirlyGlobeLib/include/VectorManager.h
+++ b/common/WhirlyGlobeLib/include/VectorManager.h
@@ -63,27 +63,26 @@ typedef enum {TextureProjectionNone,TextureProjectionTanPlane,TextureProjectionS
 class VectorInfo : public BaseInfo
 {
 public:
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
-    
-    VectorInfo();
+    VectorInfo() = default;
     VectorInfo(const Dictionary &dict);
     virtual ~VectorInfo() = default;
 
     // Convert contents to a string for debugging
-    virtual std::string toString();
-    
-    bool                        filled;
-    float                       sample;
-    SimpleIdentity              texId;
-    Point2f                     texScale;
-    float                       subdivEps;
-    bool                        gridSubdiv;
-    TextureProjections          texProj;
-    RGBAColor                   color;
-    float                       lineWidth;
-    bool                        centered;
-    bool                        vecCenterSet;
-    Point2f                     vecCenter;
+    virtual std::string toString() const override;
+
+    bool                        filled = false;
+    float                       sample = 0.0f;
+    SimpleIdentity              texId = EmptyIdentity;
+    Point2f                     texScale = { 1.0f, 1.0f };
+    float                       subdivEps = 0.0f;
+    bool                        gridSubdiv = false;
+    TextureProjections          texProj = TextureProjectionNone;
+    RGBAColor                   color = RGBAColor::white();
+    float                       lineWidth = 1.0f;
+    bool                        centered = true;
+    bool                        vecCenterSet = false;
+    bool                        closeAreals = true;
+    Point2f                     vecCenter = { 0.0f, 0.0f };
     FloatExpressionInfoRef      opacityExp;
     ColorExpressionInfoRef      colorExp;
 };

--- a/common/WhirlyGlobeLib/include/WideVectorManager.h
+++ b/common/WhirlyGlobeLib/include/WideVectorManager.h
@@ -51,23 +51,29 @@ typedef enum {WideVecImplBasic,WideVecImplPerf} WideVecImplType;
 class WideVectorInfo : public BaseInfo
 {
 public:
-    WideVectorInfo();
+    WideVectorInfo() = default;
     WideVectorInfo(const Dictionary &dict);
     virtual ~WideVectorInfo() = default;
 
-    WideVecImplType implType;
-    RGBAColor color;
-    float width;
-    float offset;
-    float repeatSize;
-    float edgeSize;
-    float subdivEps;
-    WideVectorCoordsType coordType;
-    WideVectorLineJoinType joinType;
-    WideVectorLineCapType capType;
-    SimpleIdentity texID;
-    float miterLimit;
-    
+    // Convert contents to a string for debugging
+    virtual std::string toString() const override;
+
+    WideVecImplType implType = WideVecImplBasic;
+    RGBAColor color = RGBAColor::white();
+    float width = 2.0f;
+    float offset = 0.0f;
+    float repeatSize = 32.0f;
+    float edgeSize = 1.0f;
+    float subdivEps = 0.0f;
+    float miterLimit = 2.0f;
+    bool closeAreals = true;
+
+    WideVectorCoordsType coordType = WideVecCoordScreen;
+    WideVectorLineJoinType joinType = WideVecMiterJoin;
+    WideVectorLineCapType capType = WideVecButtCap;
+
+    SimpleIdentity texID = EmptyIdentity;
+
     FloatExpressionInfoRef widthExp;
     FloatExpressionInfoRef offsetExp;
     FloatExpressionInfoRef opacityExp;

--- a/common/WhirlyGlobeLib/src/BaseInfo.cpp
+++ b/common/WhirlyGlobeLib/src/BaseInfo.cpp
@@ -248,31 +248,28 @@ std::string to_string(T value)
     return os.str();
 }
 
-std::string BaseInfo::toString()
+std::string BaseInfo::toString() const
 {
-    std::string outStr =
-    (std::string)"minVis = " + to_string(minVis) + ";" +
-    " maxVis = " + to_string(maxVis) + ";" +
-    " minVisBand = " + to_string(minVisBand) + ";" +
-    " maxVisBand = " + to_string(maxVisBand) + ";" +
-    " minViewerDist = " + to_string(minViewerDist) + ";" +
-    " maxViewerDist = " + to_string(maxViewerDist) + ";" +
-    " zoomSlot = " + to_string(zoomSlot) + ";" +
-    " minZoomVis = " + to_string(minZoomVis) + ";" +
-    " maxZoomVis = " + to_string(maxZoomVis) + ";" +
-    " viewerCenter = (" + to_string(viewerCenter.x()) + "," + to_string(viewerCenter.y()) + "," + to_string(viewerCenter.z()) + ");" +
-    " drawOffset = " + to_string(drawOffset) + ";" +
-    " drawPriority = " + to_string(drawPriority) + ";" +
-    " enable = " + (enable ? "yes" : "no") + ";" +
-    " fade = " + to_string(fade) + ";" +
-    " fadeIn = " + to_string(fadeIn) + ";" +
-    " fadeOut = " + to_string(fadeOut) + ";" +
-    " fadeOutTime = " + to_string(fadeOutTime) + ";" +
-    " startEnable = " + to_string(startEnable) + ";" +
-    " endEnable = " + to_string(endEnable) + ";" +
-    " programID = " + to_string(programID) + ";";
-    
-    return outStr;
+    return "minVis = " + to_string(minVis) + ";" +
+           " maxVis = " + to_string(maxVis) + ";" +
+           " minVisBand = " + to_string(minVisBand) + ";" +
+           " maxVisBand = " + to_string(maxVisBand) + ";" +
+           " minViewerDist = " + to_string(minViewerDist) + ";" +
+           " maxViewerDist = " + to_string(maxViewerDist) + ";" +
+           " zoomSlot = " + to_string(zoomSlot) + ";" +
+           " minZoomVis = " + to_string(minZoomVis) + ";" +
+           " maxZoomVis = " + to_string(maxZoomVis) + ";" +
+           " viewerCenter = (" + to_string(viewerCenter.x()) + "," + to_string(viewerCenter.y()) + "," + to_string(viewerCenter.z()) + ");" +
+           " drawOffset = " + to_string(drawOffset) + ";" +
+           " drawPriority = " + to_string(drawPriority) + ";" +
+           " enable = " + (enable ? "yes" : "no") + ";" +
+           " fade = " + to_string(fade) + ";" +
+           " fadeIn = " + to_string(fadeIn) + ";" +
+           " fadeOut = " + to_string(fadeOut) + ";" +
+           " fadeOutTime = " + to_string(fadeOutTime) + ";" +
+           " startEnable = " + to_string(startEnable) + ";" +
+           " endEnable = " + to_string(endEnable) + ";" +
+           " programID = " + to_string(programID) + ";";
 }
     
 void BaseInfo::setupBasicDrawable(const BasicDrawableBuilderRef &drawBuild) const

--- a/common/WhirlyGlobeLib/src/ShapeDrawableBuilder.cpp
+++ b/common/WhirlyGlobeLib/src/ShapeDrawableBuilder.cpp
@@ -33,19 +33,12 @@ namespace WhirlyKit
 {
 
 ShapeInfo::ShapeInfo()
-    : color(RGBAColor(255,255,255,255))
-    , lineWidth(1.0)
-    , insideOut(false)
-    , hasCenter(false)
-    , center(0.0,0.0,0.0)
 {
     zBufferRead = true;
 }
 
 ShapeInfo::ShapeInfo(const Dictionary &dict)
     : BaseInfo(dict)
-    , hasCenter(false)
-    , center(0,0,0)
 {
     zBufferRead = dict.getBool(MaplyZBufferRead, true);
     color = dict.getColor(MaplyColor,RGBAColor(255,255,255,255));

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/MaplySharedAttributes.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/MaplySharedAttributes.h
@@ -224,6 +224,9 @@ extern NSString* const kMaplyWideVecCoordTypeScreen;
 /// Controls the wide vector implementation.  Basic implementation by default.
 extern NSString* const kMaplyWideVecImpl;
 
+/// Default/old implementation of the wide vectors
+extern NSString* const kMaplyWideVecImplDefault;
+
 /// Performance implementation of the wide vectors
 extern NSString* const kMaplyWideVecImplPerf;
 
@@ -264,6 +267,9 @@ extern NSString* const kMaplyWideVecTexRepeatLen;
 
 /// Offset to left (negative) or right (positive) of the centerline
 extern NSString* const kMaplyWideVecOffset;
+
+/// Close any un-closed areal features when drawing lines for them
+extern NSString* const kMaplyVecCloseAreals;
 
 /// If set we'll break up a vector feature to the given epsilon on a globe surface
 extern NSString* const kMaplySubdivEpsilon;

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
@@ -1779,9 +1779,12 @@ static inline bool dictBool(const NSDictionary *dict, const NSString *key, bool 
     std::vector<VectorShapeRef> shapes;
     for (const MaplyVectorObject *vecObj in vectors)
     {
-        for (auto shape: vecObj->vObj->shapes) {
-            auto dict = std::dynamic_pointer_cast<iosMutableDictionary>(shape->getAttrDict());
-            [self resolveMaskIDs:dict->dict compObj:compObj];
+        for (const auto &shape: vecObj->vObj->shapes)
+        {
+            if (auto dict = dynamic_cast<const iosMutableDictionary*>(shape->getAttrDictRef().get()))
+            {
+                [self resolveMaskIDs:dict->dict compObj:compObj];
+            }
         }
 
         // Maybe need to make a copy if we're going to sample

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplySharedAttributes.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplySharedAttributes.mm
@@ -1,5 +1,4 @@
-/*
- *  MaplySharedAttributes.h
+/*  MaplySharedAttributes.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Ranen Ghosh on 2/24/16.
@@ -15,13 +14,16 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 // We pull in as many of the shared attributes as possible
+// Declare strings as ObjC for this compilation unit.
 #define WKString(str) @str
+
 #import "SharedAttributes.h"
 #import "MaplySharedAttributes.h"
+
+#define WKDefineConst(N) NSString* const kMaply##N = Maply##N;
 
 /// Use this hint to turn the zbuffer on or off.  Pass in an NSNumber boolean.  Takes effect on the next frame.
 NSString* const kMaplyRenderHintZBuffer = MaplyRenderHintZBuffer;
@@ -224,11 +226,16 @@ NSString* const kMaplyWideVecMiterLimit = MaplyWideVecMiterLimit;
 /// It's real world coordinates for kMaplyWideVecCoordTypeReal and pixel size for kMaplyWideVecCoordTypeScreen
 NSString* const kMaplyWideVecTexRepeatLen = MaplyWideVecTexRepeatLen;
 
-NSString* const kMaplyWideVecImpl = MaplyWideVecImpl;
-NSString* const kMaplyWideVecImplPerf = MaplyWideVecImplPerf;
+/// Controls the wide vector implementation.  Basic implementation by default.
+WKDefineConst(WideVecImpl)
+WKDefineConst(WideVecImplDefault)
+WKDefineConst(WideVecImplPerf)
 
 /// Offset to left (negative) or right (positive) of the centerline
-NSString* const kMaplyWideVecOffset = MaplyWideVecOffset;
+WKDefineConst(WideVecOffset)
+
+/// Close any un-closed areal features when drawing lines for them
+WKDefineConst(VecCloseAreals)
 
 /// If set we'll break up a vector feature to the given epsilon on a globe surface
 NSString* const kMaplySubdivEpsilon = MaplySubdivEpsilon;


### PR DESCRIPTION
Fix an issue where `VectorInfo::sample` could only be set to 0 or 1.
Normalize some info struct details, move default initializers to declaration.