### PR TITLE
Fix a few potential memory leaks

### DIFF
--- a/common/WhirlyGlobeLib/include/ChangeRequest.h
+++ b/common/WhirlyGlobeLib/include/ChangeRequest.h
@@ -1,9 +1,8 @@
-/*
- *  ChangeRequest.h
+/*  ChangeRequest.h
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 5/8/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2022 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <vector>
@@ -67,8 +65,8 @@ class SceneRenderer;
 class ChangeRequest
 {
 public:
-    ChangeRequest();
-    virtual ~ChangeRequest();
+    ChangeRequest() = default;
+    virtual ~ChangeRequest() = default;
     
     /// Return true if this change requires a GL Flush in the thread it was executed in
     virtual bool needsFlush();
@@ -81,9 +79,9 @@ public:
     
     /// Set this if you need to be run before the active models are run
     virtual bool needPreExecute();
-    
+
     /// If non-zero we'll execute this request after the given absolute time
-    TimeInterval when;
+    TimeInterval when = 0.0;
 };
 
 /// Representation of a list of changes.  Might get more complex in the future.

--- a/common/WhirlyGlobeLib/src/ChangeRequest.cpp
+++ b/common/WhirlyGlobeLib/src/ChangeRequest.cpp
@@ -1,9 +1,8 @@
-/*
- *  ChangeRequest.cpp
+/*  ChangeRequest.cpp
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 5/8/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2022 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "ChangeRequest.h"
@@ -34,12 +32,6 @@ void RenderTeardownInfo::destroyTexture(SceneRenderer *renderer,const TextureBas
 void RenderTeardownInfo::destroyDrawable(SceneRenderer *renderer,const DrawableRef &draw)
 {
     draw->teardownForRenderer(renderer->getRenderSetupInfo(), renderer->getScene(), renderer->teardownInfo);
-}
-
-ChangeRequest::ChangeRequest() : when(0.0) { }
-
-ChangeRequest::~ChangeRequest()
-{
 }
 
 bool ChangeRequest::needsFlush() { return false; }

--- a/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
+++ b/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
@@ -300,16 +300,22 @@ bool QIFTileAsset::frameLoaded(PlatformThreadInfo *threadInfo,
                                ChangeSet &changes) {
     // Sometimes changes are made directly with the managers and we need to reflect that
     //  even if those features are immediately deleted
-    if (!loadReturn->changes.empty())
-        changes.insert(changes.end(),loadReturn->changes.begin(),loadReturn->changes.end());
+    changes.insert(changes.end(),loadReturn->changes.begin(),loadReturn->changes.end());
+    loadReturn->changes.clear();
     
     auto frame = loadReturn->frame ? findFrameFor(loadReturn->frame) : nullptr;
     if (loadReturn->frame && !frame)
     {
         if (!loadReturn->compObjs.empty())
+        {
             loader->compManager->removeComponentObjects(threadInfo,loadReturn->compObjs, changes);
+            loadReturn->compObjs.clear();
+        }
         if (!loadReturn->ovlCompObjs.empty())
+        {
             loader->compManager->removeComponentObjects(threadInfo,loadReturn->ovlCompObjs, changes);
+            loadReturn->ovlCompObjs.clear();
+        }
         wkLogLevel(Warn,"QuadImageFrameLoader: Got frame back outside of range");
         return false;
     }
@@ -317,9 +323,15 @@ bool QIFTileAsset::frameLoaded(PlatformThreadInfo *threadInfo,
     // Check the generation.  This is how we catch old data that was in transit.
     if (loadReturn->generation < loader->getGeneration()) {
         if (!loadReturn->compObjs.empty())
+        {
             loader->compManager->removeComponentObjects(threadInfo,loadReturn->compObjs, changes);
+            loadReturn->compObjs.clear();
+        }
         if (!loadReturn->ovlCompObjs.empty())
+        {
             loader->compManager->removeComponentObjects(threadInfo,loadReturn->ovlCompObjs, changes);
+            loadReturn->ovlCompObjs.clear();
+        }
 //        wkLogLevel(Debug, "QuadImageFrameLoader: Dropped an old loadReturn after a reload.");
         return true;
     }
@@ -337,8 +349,10 @@ bool QIFTileAsset::frameLoaded(PlatformThreadInfo *threadInfo,
     // Component objects (if there)
     for (const ComponentObjectRef& compObj : loadReturn->compObjs)
         compObjs.insert(compObj->getId());
+    loadReturn->compObjs.clear();
     for (const ComponentObjectRef& ovlCompObj : loadReturn->ovlCompObjs)
         ovlCompObjs.insert(ovlCompObj->getId());
+    loadReturn->ovlCompObjs.clear();
     
     if (frame) {
         // Clear out the old texture if it's there
@@ -1023,27 +1037,43 @@ void QuadImageFrameLoader::mergeLoadedTile(PlatformThreadInfo *threadInfo,QuadLo
     }
 
     // If there is a tile, then notify it
-    if (tile) {
-        if (failed) {
+    if (tile)
+    {
+        if (failed)
+        {
             tile->frameFailed(threadInfo, this, loadReturn, changes);
-        } else {
-            if (!tile->frameLoaded(threadInfo, this, loadReturn, texs, changes))
-                failed = true;
+        }
+        else if (!tile->frameLoaded(threadInfo, this, loadReturn, texs, changes))
+        {
+            failed = true;
         }
     }
 
-    // For whatever reason, didn't correctly integrate the tile
-    // so now delete everything
-    if (failed) {
+    // For whatever reason, didn't correctly integrate the tile, so now delete everything
+    if (failed)
+    {
         for (auto tex: texs)
+        {
             delete tex;
+        }
         texs.clear();
+
+        // Keep the changes created while setting up objects
+        changes.insert(changes.end(), loadReturn->changes.begin(), loadReturn->changes.end());
+        loadReturn->changes.clear();
+
+        // Remove any objects that were added
         SimpleIDSet compObjs;
         for (const auto& compObj : loadReturn->compObjs)
+        {
             compObjs.insert(compObj->getId());
+        }
         for (const auto& compObj : loadReturn->ovlCompObjs)
+        {
             compObjs.insert(compObj->getId());
+        }
         compManager->removeComponentObjects(threadInfo, compObjs, changes);
+
         loadReturn->clear();
     }
 }

--- a/common/WhirlyGlobeLib/src/QuadLoaderReturn.cpp
+++ b/common/WhirlyGlobeLib/src/QuadLoaderReturn.cpp
@@ -2,7 +2,7 @@
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 2/14/19.
- *  Copyright 2011-2021 mousebird consulting
+ *  Copyright 2011-2022 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  */
 
 #import "QuadLoaderReturn.h"
+#import "WhirlyKitLog.h"
 
 namespace WhirlyKit
 {
@@ -35,6 +36,10 @@ QuadLoaderReturn::QuadLoaderReturn(int generation) :
 
 QuadLoaderReturn::~QuadLoaderReturn()
 {
+    if (!changes.empty())
+    {
+        wkLogLevel(Warn, "LoaderReturn destroyed with %lld pending changes", changes.size());
+    }
 }
 
 void QuadLoaderReturn::clear()
@@ -43,7 +48,9 @@ void QuadLoaderReturn::clear()
     images.clear();
     compObjs.clear();
     ovlCompObjs.clear();
-}
     
+    // Note: changes are not cleared, they have to be deleted and should be handled elsewhere
+}
+
 }
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MapboxVectorInterpreter.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MapboxVectorInterpreter.mm
@@ -299,10 +299,13 @@ static int BackImageWidth = 16, BackImageHeight = 16;
         loadReturn->loadReturn->changes.insert(loadReturn->loadReturn->changes.end(),
                                                vecTileReturn->data->changes.begin(),
                                                vecTileReturn->data->changes.end());
+        vecTileReturn->data->changes.clear();
         
-        if (!vecTileReturn->data->compObjs.empty())
-            compObjs.insert(compObjs.end(),vecTileReturn->data->compObjs.begin(),vecTileReturn->data->compObjs.end());
-        
+        compObjs.insert(compObjs.end(),
+                        std::make_move_iterator(vecTileReturn->data->compObjs.begin()),
+                        std::make_move_iterator(vecTileReturn->data->compObjs.end()));
+        vecTileReturn->data->compObjs.clear();
+
         const auto it = vecTileReturn->data->categories.find("overlay");
         if (it != vecTileReturn->data->categories.end()) {
             auto const &ids = it->second;

--- a/ios/library/WhirlyGlobeLib/src/LayerThread.mm
+++ b/ios/library/WhirlyGlobeLib/src/LayerThread.mm
@@ -159,9 +159,22 @@ using namespace WhirlyKit;
 
 - (void)addChangeRequests:(std::vector<WhirlyKit::ChangeRequest *> &)newChangeRequests
 {
+    if (self.isCancelled)
+    {
+        // We're already shutting down, and we may have already
+        // cleaned up the pending changes, so just discard these.
+        for (auto req : newChangeRequests)
+        {
+            delete req;
+        }
+        newChangeRequests.clear();
+    }
+
     if (newChangeRequests.empty())
+    {
         return;
-    
+    }
+
     std::lock_guard<std::mutex> guardLock(changeLock);
 
     // If we don't have one coming, schedule a merge
@@ -193,12 +206,13 @@ using namespace WhirlyKit;
             [layer preSceneFlush:self];
     }
     inRunAddChangeRequests = false;
-    
+
+    // Copy the pending changes to a local collection within the mutex.
+    // We must not return without passing these to the scene or destroying them.
     std::vector<WhirlyKit::ChangeRequest *> changesToProcess;
     {
         std::lock_guard<std::mutex> guardLock(changeLock);
-        changesToProcess = changeRequests;
-        changeRequests.clear();
+        changesToProcess = std::move(changeRequests);
     }
 
     bool requiresFlush = false;
@@ -206,15 +220,17 @@ using namespace WhirlyKit;
     ChangeSet changesToAdd;
     for (unsigned int ii=0;ii<changesToProcess.size();ii++)
     {
-        ChangeRequest *change = changesToProcess[ii];
-        if (change)
+        if (ChangeRequest *change = changesToProcess[ii])
         {
             requiresFlush |= change->needsFlush();
             change->setupForRenderer(_renderer->getRenderSetupInfo(),_scene);
             changesToAdd.push_back(changesToProcess[ii]);
-        } else
+        }
+        else
+        {
             // A NULL change request is just a flush request
             requiresFlush = true;
+        }
     }
     
     // If anything needed a flush after that, let's do it
@@ -225,7 +241,8 @@ using namespace WhirlyKit;
         if (changesToAdd.empty())
             changesToAdd.push_back(nullptr);
     }
-    
+
+    // Pass ownership of change requests to the scene
     _scene->addChangeRequests(changesToAdd);
 }
 
@@ -302,7 +319,7 @@ using namespace WhirlyKit;
             }
             [pauseLock unlock];
         }
-        
+
         [NSObject cancelPreviousPerformRequestsWithTarget:self];
         
         [_viewWatcher stop];


### PR DESCRIPTION
More cases where the changes in `LoaderReturn` objects could be leaked when cancelling or shutting down during loading.

Only one of the two places where we pass objects between threads was protected from the thread shutting down before executing the call.

`cleanupLoadedData` was not being called in a few places where it should be, and was only being called when the weak view controller reference was valid, even though it doesn't really need that.  It also wasn't cleaning up the change requests when it was called.

There was a race where we would add things to this list of pending objects after it had already been cleaned up.

I did observe `MaplyQuadLoader shutdown` being called after the layer thread was stopped.  That might indicate a problem somewhere else, but I made it run the cleanup on the calling thread, regardless.

Collectively, these make a pretty big difference in a workload where maps are being rapidly created and destroyed, faster than they can finish loading.

<img src="https://user-images.githubusercontent.com/71895881/148461922-78bd1d44-40d5-4e50-89cc-75737e97dd5f.png" height="200"/>

<img src="https://user-images.githubusercontent.com/71895881/148461947-6c4a83a0-55b3-4131-a00e-661c30605c20.png" height="200"/>
