### PR TITLE
Change objectsAtCoord in MaplyBaseViewController to search for markers, labels and vector objects

### DIFF
--- a/ios/apps/AutoTester/AutoTester/testCases/MarkersTestCase.swift
+++ b/ios/apps/AutoTester/AutoTester/testCases/MarkersTestCase.swift
@@ -39,12 +39,56 @@ class MarkersTestCase: MaplyTestCase {
         baseCase.setUpWithGlobe(globeVC)
 		insertMarkers(baseCase.vecList!, theViewC: globeVC)
 		globeVC.animate(toPosition: MaplyCoordinateMakeWithDegrees(151.211111, -33.859972), time: 1.0)
+
+        addLongPressGesture()
 	}
 
 	override func setUpWithMap(_ mapVC: MaplyViewController) {
 		baseCase.setUpWithMap(mapVC)
 		insertMarkers(baseCase.vecList!, theViewC: mapVC)
 		mapVC.animate(toPosition: MaplyCoordinateMakeWithDegrees(151.211111, -33.859972), time: 1.0)
-	}
 
+        addLongPressGesture()
+	}
+}
+
+// MARK: - Long Press
+
+extension MarkersTestCase {
+
+    private func addLongPressGesture() {
+
+        let gesture = UILongPressGestureRecognizer(target: self, action: #selector(longPressed(_:)))
+        baseViewController?.view.addGestureRecognizer(gesture)
+    }
+
+    @objc
+    private func longPressed(_ gesture: UILongPressGestureRecognizer) {
+
+        let point = gesture.location(in: gesture.view)
+        var loc: MaplyCoordinate?
+
+        if let mapViewController = mapViewController {
+            loc = mapViewController.geo(fromScreenPoint: point)
+        } else if let globeViewController = globeViewController {
+            loc = globeViewController.geoPoint(fromScreen: point)?.maplyCoordinateValue
+        }
+        guard let loc = loc else {
+            return
+        }
+        showObjectsCount(at: loc)
+    }
+
+    private func showObjectsCount(at coord: MaplyCoordinate) {
+
+        guard let viewC = baseViewController else {
+            return
+        }
+        let objs = viewC.objects(atCoord: coord) ?? []
+        let vc = UIAlertController(title: nil, message: "\(objs.count) selectable objects found at tapped location", preferredStyle: .alert)
+        viewC.present(vc, animated: true, completion: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            viewC.dismiss(animated: true, completion: nil)
+        }
+    }
 }

--- a/ios/apps/AutoTester/AutoTester/testCases/MarkersTestCase.swift
+++ b/ios/apps/AutoTester/AutoTester/testCases/MarkersTestCase.swift
@@ -85,9 +85,11 @@ extension MarkersTestCase {
             return
         }
         let objs = viewC.objects(atCoord: coord) ?? []
-        let vc = UIAlertController(title: nil, message: "\(objs.count) selectable objects found at tapped location", preferredStyle: .alert)
+        let labelsAndMarkers = viewC.labelsAndMarkers(atCoord: coord) ?? []
+
+        let vc = UIAlertController(title: nil, message: "\(objs.count) selectable vector objects and \(labelsAndMarkers.count) selectable labels and markers found at tapped location", preferredStyle: .alert)
         viewC.present(vc, animated: true, completion: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             viewC.dismiss(animated: true, completion: nil)
         }
     }

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/control/MaplyBaseViewController.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/control/MaplyBaseViewController.h
@@ -1462,13 +1462,22 @@ typedef double (^ZoomEasingBlock)(double z0,double z1,double t);
 - (void)disable3dTouchSelection;
 
 /** 
-    Return all the selectable objects at the given location.
+    Return all the selectable vector objects at the given location.
     
     Objects can be selected via the delegate or the search can be run directly here.
     
     This is not thread safe and will block the main thread.
   */
 - (NSArray * _Nullable)objectsAtCoord:(MaplyCoordinate)coord;
+
+/**
+    Return all the selectable labels and markers at the given location.
+
+    Objects can be selected via the delegate or the search can be run directly here.
+
+    This is not thread safe and will block the main thread.
+ */
+- (NSArray * _Nullable)labelsAndMarkersAtCoord:(MaplyCoordinate)coord;
 
 /// Turn on/off performance output (goes to the log periodically).
 @property (nonatomic,assign) bool performanceOutput;

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyBaseInteractionLayer_private.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyBaseInteractionLayer_private.h
@@ -208,7 +208,11 @@
 - (NSArray *__nullable)findVectorsInPoint:(WhirlyKit::Point2f)pt;
 - (NSArray *__nullable)findVectorsInPoint:(WhirlyKit::Point2f)pt inView:(MaplyBaseViewController*__nullable)vc multi:(bool)multi;
 
+// Find MaplySelectableObjects at a screen point
 - (NSObject*__nullable)selectLabelsAndMarkerForScreenPoint:(CGPoint)screenPoint;
+- (NSMutableArray*__nullable)selectMultipleLabelsAndMarkersForScreenPoint:(CGPoint)screenPoint;
+- (NSMutableArray*__nullable)convertSelectedObjects:(std::vector<WhirlyKit::SelectionManager::SelectedObject>)selectedObjs;
+- (NSMutableArray*__nullable)convertSelectedVecObjects:(NSArray<MaplyVectorObject *>*__nullable)vecObjs;
 
 // Find the Maply object corresponding to the given ID (from the selection manager).
 // Thread-safe

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyBaseInteractionLayer_private.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyBaseInteractionLayer_private.h
@@ -205,7 +205,6 @@
 - (void)removeImageTexture:(MaplyTexture *__nonnull)tex changes:(WhirlyKit::ChangeSet &)changes;
 
 // Do a point in poly check for vectors we're representing
-- (NSArray *__nullable)findVectorsInPoint:(WhirlyKit::Point2f)pt;
 - (NSArray *__nullable)findVectorsInPoint:(WhirlyKit::Point2f)pt inView:(MaplyBaseViewController*__nullable)vc multi:(bool)multi;
 
 // Find MaplySelectableObjects at a screen point

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyBaseInteractionLayer_private.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyBaseInteractionLayer_private.h
@@ -210,7 +210,7 @@
 // Find MaplySelectableObjects at a screen point
 - (NSObject*__nullable)selectLabelsAndMarkerForScreenPoint:(CGPoint)screenPoint;
 - (NSMutableArray*__nullable)selectMultipleLabelsAndMarkersForScreenPoint:(CGPoint)screenPoint;
-- (NSMutableArray*__nullable)convertSelectedObjects:(std::vector<WhirlyKit::SelectionManager::SelectedObject>)selectedObjs;
+- (NSMutableArray*__nullable)convertSelectedObjects:(const std::vector<WhirlyKit::SelectionManager::SelectedObject> &)selectedObjs;
 - (NSMutableArray*__nullable)convertSelectedVecObjects:(NSArray<MaplyVectorObject *>*__nullable)vecObjs;
 
 // Find the Maply object corresponding to the given ID (from the selection manager).

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
@@ -3668,28 +3668,25 @@ typedef std::set<GeomModelInstances *,struct GeomModelInstancesCmp> GeomModelIns
     return retSelectArr;
 }
 
-- (NSMutableArray*)convertSelectedObjects:(std::vector<SelectionManager::SelectedObject>)selectedObjs
+- (NSMutableArray*__nullable)convertSelectedObjects:(const std::vector<WhirlyKit::SelectionManager::SelectedObject> &)selectedObjs
 {
     NSMutableArray *retSelectArr = [NSMutableArray array];
-    if (!selectedObjs.empty())
+    // Work through the objects the manager found, creating entries for each
+    for (unsigned int ii = 0; ii < selectedObjs.size(); ii++)
     {
-        // Work through the objects the manager found, creating entries for each
-        for (unsigned int ii=0;ii<selectedObjs.size();ii++)
+        const SelectionManager::SelectedObject &theSelObj = selectedObjs[ii];
+
+        for (auto selectID : theSelObj.selectIDs)
         {
-            SelectionManager::SelectedObject &theSelObj = selectedObjs[ii];
+            MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
+            selObj.selectedObj = compManager->getSelectObject(selectID);
 
-            for (auto selectID : theSelObj.selectIDs)
-            {
-                MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
-                selObj.selectedObj = compManager->getSelectObject(selectID);
+            selObj.screenDist = theSelObj.screenDist;
+            selObj.cluster = theSelObj.isCluster;
+            selObj.zDist = theSelObj.distIn3D;
 
-                selObj.screenDist = theSelObj.screenDist;
-                selObj.cluster = theSelObj.isCluster;
-                selObj.zDist = theSelObj.distIn3D;
-
-                if (selObj.selectedObj)
-                    [retSelectArr addObject:selObj];
-            }
+            if (selObj.selectedObj)
+                [retSelectArr addObject:selObj];
         }
     }
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
@@ -3631,11 +3631,6 @@ typedef std::set<GeomModelInstances *,struct GeomModelInstancesCmp> GeomModelIns
 
 // Search for a point inside any of our vector objects
 // Runs in layer thread
-- (NSArray *)findVectorsInPoint:(Point2f)pt
-{
-    return [self findVectorsInPoint:pt inView:nil multi:true];
-}
-
 - (NSArray *)findVectorsInPoint:(Point2f)pt inView:(MaplyBaseViewController *)vc multi:(bool)multi
 {
     if (!layerThread || !vc || !vc->renderControl)

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseInteractionLayer.mm
@@ -3664,7 +3664,58 @@ typedef std::set<GeomModelInstances *,struct GeomModelInstancesCmp> GeomModelIns
 
 - (NSObject*)selectLabelsAndMarkerForScreenPoint:(CGPoint)screenPoint
 {
-    return nil;
+    return [[self selectMultipleLabelsAndMarkersForScreenPoint:screenPoint] firstObject];
+}
+
+- (NSMutableArray*)selectMultipleLabelsAndMarkersForScreenPoint:(CGPoint)screenPoint
+{
+    NSMutableArray *retSelectArr = [NSMutableArray array];
+    return retSelectArr;
+}
+
+- (NSMutableArray*)convertSelectedObjects:(std::vector<SelectionManager::SelectedObject>)selectedObjs
+{
+    NSMutableArray *retSelectArr = [NSMutableArray array];
+    if (!selectedObjs.empty())
+    {
+        // Work through the objects the manager found, creating entries for each
+        for (unsigned int ii=0;ii<selectedObjs.size();ii++)
+        {
+            SelectionManager::SelectedObject &theSelObj = selectedObjs[ii];
+
+            for (auto selectID : theSelObj.selectIDs)
+            {
+                MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
+                selObj.selectedObj = compManager->getSelectObject(selectID);
+
+                selObj.screenDist = theSelObj.screenDist;
+                selObj.cluster = theSelObj.isCluster;
+                selObj.zDist = theSelObj.distIn3D;
+
+                if (selObj.selectedObj)
+                    [retSelectArr addObject:selObj];
+            }
+        }
+    }
+
+    return retSelectArr;
+}
+
+- (NSMutableArray*)convertSelectedVecObjects:(NSArray<MaplyVectorObject *>*)vecObjs
+{
+    NSMutableArray *retSelectArr = [NSMutableArray array];
+
+    for (MaplyVectorObject *vecObj in vecObjs)
+    {
+        MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
+        selObj.selectedObj = vecObj;
+        selObj.screenDist = 0.0;
+        // Note: Not quite right
+        selObj.zDist = 0.0;
+        [retSelectArr addObject:selObj];
+    }
+    
+    return retSelectArr;
 }
 
 - (void)dumpStats

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseViewController.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseViewController.mm
@@ -1208,18 +1208,20 @@ static const float PerfOutputDelay = 15.0;
     }
 }
 
--(NSArray*)objectsAtCoord:(MaplyCoordinate)coord
+- (NSArray*)objectsAtCoord:(MaplyCoordinate)coord
 {
     if (!renderControl)
         return nil;
 
-    NSMutableArray *retSelectArr = [renderControl->interactLayer selectMultipleLabelsAndMarkersForScreenPoint:[self screenPointFromGeo:coord]];
+    return [renderControl->interactLayer findVectorsInPoint:Point2f(coord.x,coord.y) inView:self multi:true];
+}
 
-    NSArray *vecObjs = [renderControl->interactLayer findVectorsInPoint:Point2f(coord.x,coord.y) inView:self multi:true];
+- (NSArray*)labelsAndMarkersAtCoord:(MaplyCoordinate)coord
+{
+    if (!renderControl)
+        return nil;
 
-    [retSelectArr addObjectsFromArray:[renderControl->interactLayer convertSelectedVecObjects:vecObjs]];
-
-    return retSelectArr;
+    return [renderControl->interactLayer selectMultipleLabelsAndMarkersForScreenPoint:[self screenPointFromGeo:coord]];
 }
 
 #pragma mark - Properties

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseViewController.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyBaseViewController.mm
@@ -1212,8 +1212,14 @@ static const float PerfOutputDelay = 15.0;
 {
     if (!renderControl)
         return nil;
-    
-    return [renderControl->interactLayer findVectorsInPoint:Point2f(coord.x,coord.y)];
+
+    NSMutableArray *retSelectArr = [renderControl->interactLayer selectMultipleLabelsAndMarkersForScreenPoint:[self screenPointFromGeo:coord]];
+
+    NSArray *vecObjs = [renderControl->interactLayer findVectorsInPoint:Point2f(coord.x,coord.y) inView:self multi:true];
+
+    [retSelectArr addObjectsFromArray:[renderControl->interactLayer convertSelectedVecObjects:vecObjs]];
+
+    return retSelectArr;
 }
 
 #pragma mark - Properties

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplyInteractionLayer.mm
@@ -68,22 +68,14 @@ using namespace WhirlyGlobe;
 
 // Do the logic for a selection
 // Runs in the layer thread
-- (void) userDidTapLayerThread:(MaplyTapMessage *)msg
+- (void)userDidTapLayerThread:(MaplyTapMessage *)msg
 {
     // First, we'll look for labels and markers
     NSMutableArray *retSelectArr = [self selectMultipleLabelsAndMarkersForScreenPoint:msg.touchLoc];
     
     // Next, try the vectors
     NSArray *vecObjs = [self findVectorsInPoint:Point2f(msg.whereGeo.x(),msg.whereGeo.y()) inView:(MaplyBaseViewController*)self.viewController multi:true];
-    for (MaplyVectorObject *vecObj in vecObjs)
-    {
-        MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
-        selObj.selectedObj = vecObj;
-        selObj.screenDist = 0.0;
-        // Note: Not quite right
-        selObj.zDist = 0.0;
-        [retSelectArr addObject:selObj];
-    }
+    [retSelectArr addObjectsFromArray:[self convertSelectedVecObjects:vecObjs]];
     
     // Tell the view controller about it
     dispatch_async(dispatch_get_main_queue(),^
@@ -93,42 +85,20 @@ using namespace WhirlyGlobe;
                    );
 }
 
+// Check for a selection
+- (void)userDidTap:(MaplyTapMessage *)msg
+{
+    // Pass it off to the layer thread
+    [self performSelector:@selector(userDidTapLayerThread:) onThread:layerThread withObject:msg waitUntilDone:NO];
+}
+
 - (NSMutableArray*)selectMultipleLabelsAndMarkersForScreenPoint:(CGPoint)screenPoint
 {
     SelectionManagerRef selectManager = std::dynamic_pointer_cast<SelectionManager>(scene->getManager(kWKSelectionManager));
     std::vector<SelectionManager::SelectedObject> selectedObjs;
     selectManager->pickObjects(Point2f(screenPoint.x,screenPoint.y),10.0,mapView->makeViewState(layerThread.renderer),selectedObjs);
-    
-    NSMutableArray *retSelectArr = [NSMutableArray array];
-    if (!selectedObjs.empty())
-    {
-        // Work through the objects the manager found, creating entries for each
-        for (unsigned int ii=0;ii<selectedObjs.size();ii++)
-        {
-            SelectionManager::SelectedObject &theSelObj = selectedObjs[ii];
-            for (auto selectID : theSelObj.selectIDs)
-            {
-                MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
-                selObj.selectedObj = compManager->getSelectObject(selectID);
-                
-                selObj.screenDist = theSelObj.screenDist;
-                selObj.cluster = theSelObj.isCluster;
-                selObj.zDist = theSelObj.distIn3D;
-                
-                if (selObj.selectedObj)
-                    [retSelectArr addObject:selObj];
-            }
-        }
-    }
-    
-    return retSelectArr;
-}
 
-// Check for a selection
-- (void) userDidTap:(MaplyTapMessage *)msg
-{
-    // Pass it off to the layer thread
-    [self performSelector:@selector(userDidTapLayerThread:) onThread:layerThread withObject:msg waitUntilDone:NO];
+    return [self convertSelectedObjects:selectedObjs];
 }
 
 @end

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/WGInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/WGInteractionLayer.mm
@@ -107,7 +107,7 @@ using namespace WhirlyGlobe;
 
 // Do the logic for a selection
 // Runs in the layer thread
-- (void) userDidTapLayerThread:(WhirlyGlobeTapMessage *)msg
+- (void)userDidTapLayerThread:(WhirlyGlobeTapMessage *)msg
 {
     lastTouched = scene->getCurrentTime();
     if (autoSpinner)
@@ -124,15 +124,7 @@ using namespace WhirlyGlobe;
     
     // Next, try the vectors
     NSArray *vecObjs = [self findVectorsInPoint:Point2f(msg.whereGeo.x(),msg.whereGeo.y()) inView:(MaplyBaseViewController*)self.viewController multi:true];
-    for (MaplyVectorObject *vecObj in vecObjs)
-    {
-        MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
-        selObj.selectedObj = vecObj;
-        selObj.screenDist = 0.0;
-        // Note: Not quite right
-        selObj.zDist = 0.0;
-        [retSelectArr addObject:selObj];
-    }
+    [retSelectArr addObjectsFromArray:[self convertSelectedVecObjects:vecObjs]];
     
     // Tell the view controller about it
     dispatch_async(dispatch_get_main_queue(),^
@@ -143,16 +135,10 @@ using namespace WhirlyGlobe;
 }
 
 // Check for a selection
-- (void) userDidTap:(WhirlyGlobeTapMessage *)msg
+- (void)userDidTap:(WhirlyGlobeTapMessage *)msg
 {
     // Pass it off to the layer thread
     [self performSelector:@selector(userDidTapLayerThread:) onThread:layerThread withObject:msg waitUntilDone:NO];
-}
-
-
-
-- (NSObject*)selectLabelsAndMarkerForScreenPoint:(CGPoint)screenPoint {
-    return [[self selectMultipleLabelsAndMarkersForScreenPoint:screenPoint] firstObject];
 }
 
 - (NSMutableArray*)selectMultipleLabelsAndMarkersForScreenPoint:(CGPoint)screenPoint
@@ -160,32 +146,8 @@ using namespace WhirlyGlobe;
     SelectionManagerRef selectManager = std::dynamic_pointer_cast<SelectionManager>(scene->getManager(kWKSelectionManager));
     std::vector<SelectionManager::SelectedObject> selectedObjs;
     selectManager->pickObjects(Point2f(screenPoint.x,screenPoint.y),10.0,globeView->makeViewState(layerThread.renderer),selectedObjs);
-    
-    NSMutableArray *retSelectArr = [NSMutableArray array];
-    if (!selectedObjs.empty())
-    {
-        // Work through the objects the manager found, creating entries for each
-        for (unsigned int ii=0;ii<selectedObjs.size();ii++)
-        {
-            SelectionManager::SelectedObject &theSelObj = selectedObjs[ii];
-            
-            for (auto selectID : theSelObj.selectIDs)
-            {
-                MaplySelectedObject *selObj = [[MaplySelectedObject alloc] init];
-                selObj.selectedObj = compManager->getSelectObject(selectID);
-                
-                selObj.screenDist = theSelObj.screenDist;
-                selObj.cluster = theSelObj.isCluster;
-                selObj.zDist = theSelObj.distIn3D;
-                
-                if (selObj.selectedObj)
-                    [retSelectArr addObject:selObj];
-            }
-        }
-    }
-    
-    return retSelectArr;
-}
 
+    return [self convertSelectedObjects:selectedObjs];
+}
 
 @end

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/Maply3dTouchPreviewDelegate.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/Maply3dTouchPreviewDelegate.mm
@@ -45,14 +45,14 @@ using namespace WhirlyKit;
         if([vc isKindOfClass:[MaplyViewController class]])
         {
             const MaplyCoordinate coord = [(MaplyViewController*)vc geoFromScreenPoint:location];
-            selectedObject = [[layer findVectorsInPoint:Point2f(coord.x, coord.y)] firstObject];
+            selectedObject = [[layer findVectorsInPoint:Point2f(coord.x, coord.y) inView:vc multi:true] firstObject];
         }
         else
         { //globe
             MaplyCoordinate coord;
             if([(WhirlyGlobeViewController*)vc geoPointFromScreen:location geoCoord:&coord])
             {
-                selectedObject = [[layer findVectorsInPoint:Point2f(coord.x, coord.y)] firstObject];
+                selectedObject = [[layer findVectorsInPoint:Point2f(coord.x, coord.y) inView:vc multi:true] firstObject];
             }
         }
     }


### PR DESCRIPTION
This improvement is for https://github.com/mousebird-consulting-inc/WhirlyGlobe/issues/1489
- Exposed `selectMultipleLabelsAndMarkersForScreenPoint` function in `MaplyBaseInteractionLayer` to be able to call it from outside.
- Moved same code that converts `SelectionManager::SelectedObject` to `MaplySelectedObject` from `WGInteractionLayer.m` and `MaplyInteractionLayer.mm` to avoid code duplication. Exposed `convertSelectedObjects` and `convertSelectedVecObjects` in `MaplyBaseInteractionLayer` for this matter to use in subclasses.
- Changed `objectsAtCoord` function in `MaplyBaseViewController` to return markers, labels and vector objects at a coordinate in one array. It's one common function implementation for both Maply and WhirlyGlobe. 
- Added long press gesture to MarkersTestCase to test the `objectsAtCoord` function.