### PR TITLE
Add per-object color support for wide vectors

### DIFF
--- a/android/apps/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/WideVectorsTestCase.kt
+++ b/android/apps/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/WideVectorsTestCase.kt
@@ -80,27 +80,27 @@ class WideVectorsTestCase(activity: Activity?) :
     }
     
     private fun offsetTests(vc: BaseController): Collection<ComponentObject> {
-        val sep = 15 // separation for when/if performance implementation is supported
+        val rsep = 1.5 // separation for when/if performance implementation is supported
+        val csep = 1.2
+        val cs = 0.1
         return (0..1).flatMap { k ->
-            (0..0).flatMap { j ->
+            (0..1).flatMap { j ->
                 (0..4).flatMap { i ->
-                    val lat = 35
-                    val lon = (j+k) * sep - 80
+                    val lat = 40 - (k * rsep)
+                    val lon = j * csep - 90
                     val coords = arrayOf(
-                        Point2d.FromDegrees((-15 + i * 1 + lon).toDouble(), lat + 17.0),
-                        Point2d.FromDegrees((-10 + i * 2 + lon).toDouble(), lat + 15.0),
-                        Point2d.FromDegrees((  0 - i * 2 + lon).toDouble(), lat + 0.0),
-                        Point2d.FromDegrees((-15 + i * 1 + lon).toDouble(), lat + 17.0),
+                        Point2d.FromDegrees((-11*cs + i*1*cs + lon), lat + 13*cs),
+                        Point2d.FromDegrees(( -7*cs + i*2*cs + lon), lat + 11*cs),
+                        Point2d.FromDegrees((  0*cs - i*2*cs + lon), lat +  0*cs),
+                        Point2d.FromDegrees((-13*cs + i*1*cs + lon), lat + 13*cs),
                     )
             
                     val wideInfo = WideVectorInfo().also {
-                        if (j == 0) it.setColor(0.0f, 0.0f, 1.0f, 0.5f)
-                        else it.setColor(1.0f, 0.0f, 0.0f, 0.5f)
-                        //it.filled = false
+                        if (j == 0) it.setColor(0.0f, 0.0f, 1.0f, 0.75f)
+                        else it.setColor(1.0f, 0.0f, 0.0f, 0.75f)
                         it.enable = true
                         it.setFade(0.0)
                         it.drawPriority = VectorInfo.VectorPriorityDefault
-                        //it.centered = true
                         it.edgeFalloff = i.toDouble()
                         it.joinType = if (k == 0) WideVectorInfo.JoinType.BevelJoin else WideVectorInfo.JoinType.MiterJoin
                         it.offset = (2 * i).toDouble()
@@ -111,12 +111,21 @@ class WideVectorsTestCase(activity: Activity?) :
                     val info = VectorInfo().also {
                         it.setColor(1.0f, 0.0f, 1.0f, 0.5f)
                         it.enable = true
-                        it.drawPriority = wideInfo.drawPriority
+                        it.drawPriority = wideInfo.drawPriority + 10
                     }
             
-                    val vecObj = VectorObject.createLineString(coords)?.subdivideToGlobe(0.0001)
+                    val vecAttrs = AttrDictionary()
+                    val clAttrs = AttrDictionary()
+                    if (k > 0) {
+                        val cc = 50 * i;
+                        vecAttrs.setInt("color", Color.argb(129, 0,cc,255 - cc));
+                        clAttrs.setInt("color", Color.argb(192,0,255 - cc,cc));
+                    }
+                    val vecObj = VectorObject.createLineString(coords, vecAttrs)?.subdivideToGlobe(0.0001)
+                    val clObj = VectorObject.createLineString(coords, clAttrs)?.subdivideToGlobe(0.0001)
+                    
                     listOfNotNull(
-                        vc.addVector(vecObj, info, ThreadMode.ThreadCurrent),
+                        vc.addVector(clObj, info, ThreadMode.ThreadCurrent),
                         vc.addWideVector(vecObj, wideInfo, ThreadMode.ThreadCurrent)
                     )
                 }

--- a/ios/apps/AutoTester/AutoTester.xcodeproj/project.pbxproj
+++ b/ios/apps/AutoTester/AutoTester.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 		8F981DB91DE3577C00717DF1 /* ne_10m_roads.prj in Resources */ = {isa = PBXBuildFile; fileRef = 8F981DB31DE3577C00717DF1 /* ne_10m_roads.prj */; };
 		8F981DBB1DE3577C00717DF1 /* ne_10m_roads.shp in Resources */ = {isa = PBXBuildFile; fileRef = 8F981DB51DE3577C00717DF1 /* ne_10m_roads.shp */; };
 		8F981DBC1DE3577C00717DF1 /* ne_10m_roads.shx in Resources */ = {isa = PBXBuildFile; fileRef = 8F981DB61DE3577C00717DF1 /* ne_10m_roads.shx */; };
-		D8200C911BE92B2F00B22CF5 /* WideVectorsTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D8200C901BE92B2F00B22CF5 /* WideVectorsTestCase.m */; };
+		D8200C911BE92B2F00B22CF5 /* WideVectorsTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = D8200C901BE92B2F00B22CF5 /* WideVectorsTestCase.mm */; };
 		D8200CA11BE9563F00B22CF5 /* StickersTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8200CA01BE9563F00B22CF5 /* StickersTestCase.swift */; };
 		D8200CA41BE9624300B22CF5 /* LoftedPolysTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D8200CA31BE9624300B22CF5 /* LoftedPolysTestCase.m */; };
 		D8228A921BE77816001D6914 /* MovingScreenLabelsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8228A911BE77816001D6914 /* MovingScreenLabelsTestCase.swift */; };
@@ -1152,7 +1152,7 @@
 		8F981DB61DE3577C00717DF1 /* ne_10m_roads.shx */ = {isa = PBXFileReference; lastKnownFileType = file; name = ne_10m_roads.shx; path = ../../../resources/vectors/ne_10m_roads/ne_10m_roads.shx; sourceTree = "<group>"; };
 		8FE129181CDFB3B8004744FC /* TestCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestCell.swift; sourceTree = "<group>"; };
 		D8200C8F1BE92B2F00B22CF5 /* WideVectorsTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WideVectorsTestCase.h; sourceTree = "<group>"; };
-		D8200C901BE92B2F00B22CF5 /* WideVectorsTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WideVectorsTestCase.m; sourceTree = "<group>"; };
+		D8200C901BE92B2F00B22CF5 /* WideVectorsTestCase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WideVectorsTestCase.mm; sourceTree = "<group>"; };
 		D8200C971BE93E6E00B22CF5 /* StarsSunTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StarsSunTestCase.swift; sourceTree = "<group>"; };
 		D8200C9D1BE9516300B22CF5 /* ShapesTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShapesTestCase.h; sourceTree = "<group>"; };
 		D8200CA01BE9563F00B22CF5 /* StickersTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StickersTestCase.swift; sourceTree = "<group>"; };
@@ -1430,7 +1430,7 @@
 				2BBB70811D5E9079009B67A6 /* VectorStyleTestCase.h */,
 				2BBB70821D5E9079009B67A6 /* VectorStyleTestCase.m */,
 				D8200C8F1BE92B2F00B22CF5 /* WideVectorsTestCase.h */,
-				D8200C901BE92B2F00B22CF5 /* WideVectorsTestCase.m */,
+				D8200C901BE92B2F00B22CF5 /* WideVectorsTestCase.mm */,
 				E5679F441CB72DE800369A15 /* WMSTestCase.h */,
 				E5679F451CB72DE800369A15 /* WMSTestCase.m */,
 			);
@@ -2631,7 +2631,7 @@
 				2B4B30AD2395E0DE00854073 /* LayerStartupShutdownTestCase.swift in Sources */,
 				E5679F4A1CB72DE800369A15 /* FindHeightTestCase.m in Sources */,
 				2B158BEF1D5D19E900103E04 /* VectorHoleTestCase.m in Sources */,
-				D8200C911BE92B2F00B22CF5 /* WideVectorsTestCase.m in Sources */,
+				D8200C911BE92B2F00B22CF5 /* WideVectorsTestCase.mm in Sources */,
 				2B446AAE21EFE29B0078A975 /* WMSTestCase.m in Sources */,
 				2BFC7E511D132DCB0040E2A3 /* ScreenMarkersTestCase.m in Sources */,
 				2BC41C8321F00AA6002926B7 /* BNGCustomMapTestCase.swift in Sources */,

--- a/ios/apps/AutoTester/AutoTester/testCases/VectorsTestCase.h
+++ b/ios/apps/AutoTester/AutoTester/testCases/VectorsTestCase.h
@@ -3,7 +3,7 @@
 //  AutoTester
 //
 //  Created by jmnavarro on 29/10/15.
-//  Copyright 2015-2017 mousebird consulting.
+//  Copyright 2015-2022 mousebird consulting.
 //
 
 #import "MaplyTestCase.h"

--- a/ios/apps/AutoTester/AutoTester/testCases/VectorsTestCase.mm
+++ b/ios/apps/AutoTester/AutoTester/testCases/VectorsTestCase.mm
@@ -42,6 +42,7 @@
         kMaplyFade: @(0.2),
     };
     NSDictionary *wideDict = @{
+        kMaplyWideVecImpl: kMaplyWideVecImplPerf,
         kMaplyDrawPriority: @(kMaplyVectorDrawPriorityDefault),
         kMaplyVecCloseAreals: @(false),
         kMaplyColor: [UIColor whiteColor],

--- a/ios/library/WhirlyGlobeLib/src/Dictionary_NSDictionary.mm
+++ b/ios/library/WhirlyGlobeLib/src/Dictionary_NSDictionary.mm
@@ -361,7 +361,8 @@ MutableDictionaryRef iosMutableDictionary::copy() const
 /// Returns true if the field exists
 bool iosMutableDictionary::hasField(const std::string &name) const
 {
-    return [dict objectForKey:StdStringToString(name)] != nil;
+    const id value = [dict objectForKey:StdStringToString(name)];
+    return (value != nil) && ![value isKindOfClass:NSNull.class];
 }
 
 /// Returns the field type


### PR DESCRIPTION
I was a little surprised that this just worked on the first try.

It boils down to just calling `drawable->setColor(color)` for each object if we're in individual-color mode, and flushing any time it changes.  Am I missing anything?

<img src="https://user-images.githubusercontent.com/71895881/151622924-cd4d5db5-4f28-494a-ad50-187b13791ba4.png" height="500"/> <img src="https://user-images.githubusercontent.com/71895881/151627504-c018c796-1241-407a-b225-9bd5ba08d767.jpg" height="500"/>

Resolves #1480.
