### PR TITLE
Fix incorrect use of font texture manager

### DIFF
--- a/common/WhirlyGlobeLib/include/ComponentManager.h
+++ b/common/WhirlyGlobeLib/include/ComponentManager.h
@@ -196,7 +196,6 @@ public:
     LoftManagerRef loftManager;
     BillboardManagerRef billManager;
     GeometryManagerRef geomManager;
-    FontTextureManagerRef fontTexManager;
     ParticleSystemManagerRef partSysManager;
 
 protected:

--- a/common/WhirlyGlobeLib/src/ComponentManager.cpp
+++ b/common/WhirlyGlobeLib/src/ComponentManager.cpp
@@ -82,7 +82,6 @@ void ComponentManager::setScene(Scene *scene)
     loftManager       = scene ? scene->getManager<LoftManager>(kWKLoftedPolyManager) : nullptr;
     billManager       = scene ? scene->getManager<BillboardManager>(kWKBillboardManager) : nullptr;
     geomManager       = scene ? scene->getManager<GeometryManager>(kWKGeometryManager) : nullptr;
-    fontTexManager    = scene ? scene->getFontTextureManager() : nullptr;
     partSysManager    = scene ? scene->getManager<ParticleSystemManager>(kWKParticleSystemManager) : nullptr;
 }
 
@@ -242,13 +241,16 @@ void ComponentManager::removeComponentObjects(PlatformThreadInfo *threadInfo,
             geomManager->removeGeometry(compObj->geomIDs, changes);
         if (!compObj->drawStringIDs.empty())
         {
-            // Giving the fonts 2s to stick around
-            //       This avoids problems with texture being paged out.
-            //       Without this we lose the textures before we're done with them
-            const TimeInterval when = scene->getCurrentTime() + 2.0;
-            for (SimpleIdentity dStrID : compObj->drawStringIDs)
+            if (const auto ftm = scene ? scene->getFontTextureManager() : nullptr)
             {
-                fontTexManager->removeString(threadInfo, dStrID, changes, when);
+                // Giving the fonts 2s to stick around
+                //       This avoids problems with texture being paged out.
+                //       Without this we lose the textures before we're done with them
+                const TimeInterval when = scene->getCurrentTime() + 2.0;
+                for (SimpleIdentity dStrID : compObj->drawStringIDs)
+                {
+                    ftm->removeString(threadInfo, dStrID, changes, when);
+                }
             }
         }
         for (const auto partSysID : compObj->partSysIDs)


### PR DESCRIPTION
Don't capture the scene's font texture manager at setup, as it may not yet be initialized and getting it when needed is cheap.

Resolves #1500 
