### PR TITLE
Fix crash on pinch gesture

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/MaplyPinchDelegate.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/MaplyPinchDelegate.mm
@@ -46,12 +46,12 @@ using namespace Maply;
 // Called for pinch actions
 - (void)pinchGesture:(id)sender
 {
-	UIPinchGestureRecognizer *pinch = sender;
+    UIPinchGestureRecognizer *pinch = sender;
     if ([pinch numberOfTouches] < 2)
     {
         return;
     }
-	UIGestureRecognizerState theState = pinch.state;
+    UIGestureRecognizerState theState = pinch.state;
     UIView<WhirlyKitViewWrapper> *wrapView = (UIView<WhirlyKitViewWrapper> *)pinch.view;
     SceneRenderer *sceneRenderer = wrapView.renderer;
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/MaplyPinchDelegate.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/MaplyPinchDelegate.mm
@@ -47,6 +47,10 @@ using namespace Maply;
 - (void)pinchGesture:(id)sender
 {
 	UIPinchGestureRecognizer *pinch = sender;
+    if ([pinch numberOfTouches] < 2)
+    {
+        return;
+    }
 	UIGestureRecognizerState theState = pinch.state;
     UIView<WhirlyKitViewWrapper> *wrapView = (UIView<WhirlyKitViewWrapper> *)pinch.view;
     SceneRenderer *sceneRenderer = wrapView.renderer;


### PR DESCRIPTION
This fixes a crash in pinch gesture when actively tap with 1, 2 and 3 fingers to trigger a pinch gesture.
Crash happens in `CGPoint t1 = [pinch locationOfTouch:1 inView:pinch.view];` because gesture can have only 1 touch here for some reason. 

<img width="1394" alt="Screenshot 2022-02-07 at 16 08 54" src="https://user-images.githubusercontent.com/9693643/152804208-e41b7b69-4b6b-4d25-b0dc-9660bb4989c7.png">

