### PR TITLE
Remove redundant fade option

### DIFF
--- a/android/library/maply/jni/src/base/BaseInfo_jni.cpp
+++ b/android/library/maply/jni/src/base/BaseInfo_jni.cpp
@@ -317,7 +317,8 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_BaseInfo_setFade
         BaseInfoRef *info = classInfo->getObject(env,obj);
         if (!info)
             return;
-        (*info)->fade = fade;
+        (*info)->fadeIn = fade;
+        (*info)->fadeOut = fade;
     }
     catch (...)
     {

--- a/common/WhirlyGlobeLib/include/BaseInfo.h
+++ b/common/WhirlyGlobeLib/include/BaseInfo.h
@@ -94,7 +94,7 @@ struct BaseInfo
 {
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW;
 
-    BaseInfo();
+    BaseInfo() = default;
     BaseInfo(const BaseInfo &that);
     BaseInfo(const Dictionary &dict);
     
@@ -109,26 +109,31 @@ struct BaseInfo
     void setupBasicDrawableInstance(BasicDrawableInstanceBuilder *drawBuild) const;
     void setupBasicDrawableInstance(const BasicDrawableInstanceBuilderRef &drawBuild) const;
 
-    double minVis,maxVis;
-    double minVisBand,maxVisBand;
-    double minViewerDist,maxViewerDist;
-    int zoomSlot;
-    double minZoomVis,maxZoomVis;
-    Point3d viewerCenter;
-    double drawOffset;
+    double minVis = DrawVisibleInvalid;
+    double maxVis = DrawVisibleInvalid;
+    double minVisBand = DrawVisibleInvalid;
+    double maxVisBand = DrawVisibleInvalid;
+    double minViewerDist = DrawVisibleInvalid;
+    double maxViewerDist = DrawVisibleInvalid;
+    double minZoomVis = DrawVisibleInvalid;
+    double maxZoomVis = DrawVisibleInvalid;
+    int zoomSlot = -1;
+    Point3d viewerCenter = {DrawVisibleInvalid,DrawVisibleInvalid,DrawVisibleInvalid};
+    double drawOffset = 0.0;
     int64_t drawOrder = DrawOrderTiles;
-    int drawPriority;
-    bool enable;
-    double fade;
-    double fadeIn;
-    double fadeOut;
-    TimeInterval fadeOutTime;
-    TimeInterval startEnable,endEnable;
-    SimpleIdentity programID;
-    int extraFrames;
-    bool zBufferRead,zBufferWrite;
-    SimpleIdentity renderTargetID;
-    bool hasExp;   // Set if we're requiring the expressions to be passed through (problem on Metal)
+    int drawPriority = 0;
+    bool enable = true;
+    TimeInterval fadeIn = 0.0;
+    TimeInterval fadeOut = 0.0;
+    TimeInterval fadeOutTime = 0.0;
+    TimeInterval startEnable = 0.0;
+    TimeInterval endEnable = 0.0;
+    SimpleIdentity programID = EmptyIdentity;
+    int extraFrames = 0;
+    bool zBufferRead = false;
+    bool zBufferWrite = false;
+    SimpleIdentity renderTargetID = EmptyIdentity;
+    bool hasExp = false;   // Set if we're requiring the expressions to be passed through (problem on Metal)
     
     SingleVertexAttributeSet uniforms;
 

--- a/common/WhirlyGlobeLib/include/BillboardManager.h
+++ b/common/WhirlyGlobeLib/include/BillboardManager.h
@@ -94,19 +94,17 @@ public:
 typedef std::shared_ptr<BillboardInfo> BillboardInfoRef;
 
 /// Used internally to track billboard geometry
-class BillboardSceneRep : public Identifiable
+struct BillboardSceneRep : public Identifiable
 {
-public:
-    BillboardSceneRep();
-    BillboardSceneRep(SimpleIdentity inId);
-    ~BillboardSceneRep() = default;
+    BillboardSceneRep() = default;
+    BillboardSceneRep(SimpleIdentity inId) : Identifiable(inId) {}
 
     // Clear the contents out of the scene
     void clearContents(SelectionManagerRef &selectManager,ChangeSet &changes,TimeInterval when);
 
     SimpleIDSet drawIDs;  // Drawables created for this
     SimpleIDSet selectIDs;  // IDs used for selection
-    float fade;  // Time to fade away for removal
+    float fadeOut = 0.0;  // Time to fade away for removal
 };
 
 typedef std::set<BillboardSceneRep *,IdentifiableSorter> BillboardSceneRepSet;

--- a/common/WhirlyGlobeLib/include/LoftManager.h
+++ b/common/WhirlyGlobeLib/include/LoftManager.h
@@ -60,15 +60,13 @@ typedef std::shared_ptr<LoftedPolyInfo> LoftedPolyInfoRef;
 /** Representation of one or more lofted polygons.
  Used to keep track of the assets we create.
  */
-class LoftedPolySceneRep : public WhirlyKit::Identifiable
+struct LoftedPolySceneRep : public WhirlyKit::Identifiable
 {
-public:
-    LoftedPolySceneRep() { }
+    LoftedPolySceneRep() = default;
     LoftedPolySceneRep(SimpleIdentity theId) : Identifiable(theId) { }
-    ~LoftedPolySceneRep() { }
     
     WhirlyKit::SimpleIDSet drawIDs;  // Drawables created for this
-    float fade;            // Fade out, used for delete
+    float fadeOut = 0.0;            // Fade out, used for delete
 };
 typedef std::set<LoftedPolySceneRep *,IdentifiableSorter> LoftedPolySceneRepSet;
 

--- a/common/WhirlyGlobeLib/include/ShapeManager.h
+++ b/common/WhirlyGlobeLib/include/ShapeManager.h
@@ -43,7 +43,7 @@ struct ShapeSceneRep : public Identifiable
 
     SimpleIDSet drawIDs;  // Drawables created for this
     SimpleIDSet selectIDs;  // IDs in the selection layer
-    float fade;  // Time to fade away for removal
+    float fadeOut = 0.0;  // Time to fade away for removal
 };
     
 typedef std::set<ShapeSceneRep *,IdentifiableSorter> ShapeSceneRepSet;

--- a/common/WhirlyGlobeLib/include/VectorManager.h
+++ b/common/WhirlyGlobeLib/include/VectorManager.h
@@ -45,7 +45,7 @@ namespace WhirlyKit
 class VectorSceneRep : public Identifiable
 {
 public:
-    VectorSceneRep() : fade(0.0) { }
+    VectorSceneRep() = default;
     VectorSceneRep(SimpleIdentity theId) : Identifiable(theId) { }
     
     // Clean out the representation
@@ -53,7 +53,7 @@ public:
     
     SimpleIDSet drawIDs;    // The drawables we created
     SimpleIDSet instIDs;    // Instances if we're doing that
-    float fade;       // If set, the amount of time to fade out before deletion
+    float fadeOut = 0.0;       // If set, the amount of time to fade out before deletion
 };
 typedef std::set<VectorSceneRep *,IdentifiableSorter> VectorSceneRepSet;
 

--- a/common/WhirlyGlobeLib/include/WideVectorManager.h
+++ b/common/WhirlyGlobeLib/include/WideVectorManager.h
@@ -86,7 +86,7 @@ typedef std::shared_ptr<WideVectorInfo> WideVectorInfoRef;
 struct WideVectorSceneRep : public Identifiable
 {
     WideVectorSceneRep() = default;
-    WideVectorSceneRep(SimpleIdentity inId) : Identifiable(inId), fade(0.0) {
+    WideVectorSceneRep(SimpleIdentity inId) : Identifiable(inId), fadeOut(0.0) {
     }
     ~WideVectorSceneRep() = default;
     
@@ -95,7 +95,7 @@ struct WideVectorSceneRep : public Identifiable
     
     SimpleIDSet drawIDs;
     SimpleIDSet instIDs;    // Instances if we're doing that
-    float fade = 0.0f;
+    float fadeOut = 0.0f;
 };
 
 typedef std::set<WideVectorSceneRep *,IdentifiableSorter> WideVectorSceneRepSet;

--- a/common/WhirlyGlobeLib/src/BaseInfo.cpp
+++ b/common/WhirlyGlobeLib/src/BaseInfo.cpp
@@ -134,31 +134,12 @@ Vector4f ColorExpressionInfo::evaluateF(float zoom, RGBAColor def)
     return evalExpr<RGBAColor,Vector4f>(zoom,base,def,stopInputs,stopOutputs,toVec,lerpVec);
 }
 
-BaseInfo::BaseInfo()
-    : minVis(DrawVisibleInvalid), maxVis(DrawVisibleInvalid),
-    minVisBand(DrawVisibleInvalid), maxVisBand(DrawVisibleInvalid),
-    minViewerDist(DrawVisibleInvalid), maxViewerDist(DrawVisibleInvalid),
-    zoomSlot(-1),minZoomVis(DrawVisibleInvalid),maxZoomVis(DrawVisibleInvalid),
-    viewerCenter(DrawVisibleInvalid,DrawVisibleInvalid,DrawVisibleInvalid),
-    drawOffset(0.0),
-    drawPriority(0),
-    enable(true),
-    fade(0.0), fadeIn(0.0), fadeOut(0.0), fadeOutTime(0.0),
-    startEnable(0.0), endEnable(0.0),
-    programID(EmptyIdentity),
-    extraFrames(0),
-    zBufferRead(false), zBufferWrite(false),
-    renderTargetID(EmptyIdentity),
-    hasExp(false)
-{
-}
-
 BaseInfo::BaseInfo(const BaseInfo &that)
 : minVis(that.minVis), maxVis(that.minVis), minVisBand(that.minVisBand), maxVisBand(that.maxVisBand),
   minViewerDist(that.minViewerDist), maxViewerDist(that.maxViewerDist), zoomSlot(that.zoomSlot),
   minZoomVis(that.minZoomVis),maxZoomVis(that.maxZoomVis), viewerCenter(that.viewerCenter),
   drawOffset(that.drawOffset), drawPriority(that.drawPriority), drawOrder(that.drawOrder),
-  enable(that.enable), fade(that.fade), fadeIn(that.fadeIn), fadeOut(that.fadeOut),
+  enable(that.enable), fadeIn(that.fadeIn), fadeOut(that.fadeOut),
   fadeOutTime(that.fadeOutTime), startEnable(that.startEnable), endEnable(that.endEnable),
   programID(that.programID), extraFrames(that.extraFrames), zBufferRead(that.zBufferRead),
   zBufferWrite(that.zBufferWrite), renderTargetID(that.renderTargetID), hasExp(that.hasExp)
@@ -179,11 +160,9 @@ BaseInfo::BaseInfo(const Dictionary &dict)
     viewerCenter.x() = dict.getDouble(MaplyViewableCenterX,DrawVisibleInvalid);
     viewerCenter.y() = dict.getDouble(MaplyViewableCenterY,DrawVisibleInvalid);
     viewerCenter.z() = dict.getDouble(MaplyViewableCenterZ,DrawVisibleInvalid);
-    fade = dict.getDouble(MaplyFade,0.0);
-    fadeIn = fade;
-    fadeOut = fade;
-    fadeIn = dict.getDouble(MaplyFadeIn,fadeIn);
-    fadeOut = dict.getDouble(MaplyFadeOut,fadeOut);
+    const auto fade = dict.getDouble(MaplyFade,0.0);
+    fadeIn = dict.getDouble(MaplyFadeIn,fade);
+    fadeOut = dict.getDouble(MaplyFadeOut,fade);
     fadeOutTime = dict.getDouble(MaplyFadeOutTime,0.0);
     drawPriority = dict.getInt("priority",0);
     drawPriority = dict.getInt(MaplyDrawPriority,drawPriority);
@@ -192,13 +171,11 @@ BaseInfo::BaseInfo(const Dictionary &dict)
     enable = dict.getBool(MaplyEnable,true);
     startEnable = dict.getDouble(MaplyEnableStart,0.0);
     endEnable = dict.getDouble(MaplyEnableEnd,0.0);
-    SimpleIdentity shaderID = dict.getInt(MaplyShaderString,EmptyIdentity);
-    programID = dict.getInt("program",shaderID);
+    programID = dict.getInt("program",dict.getInt(MaplyShaderString,EmptyIdentity));
     extraFrames = dict.getInt("extraFrames",0);
     zBufferRead = dict.getBool(MaplyZBufferRead,false);
     zBufferWrite = dict.getBool(MaplyZBufferWrite, false);
     renderTargetID = dict.getInt(MaplyRenderTargetDesc,EmptyIdentity);
-    hasExp = false;
 
     // Note: Porting
     // Uniforms to be passed to shader
@@ -238,18 +215,10 @@ BaseInfo::BaseInfo(const Dictionary &dict)
     }
 #endif
 }
-    
-// Really Android?  Really?
-template <typename T>
-std::string to_string(T value)
-{
-    std::ostringstream os;
-    os << value;
-    return os.str();
-}
 
 std::string BaseInfo::toString() const
 {
+    using std::to_string;
     return "minVis = " + to_string(minVis) + ";" +
            " maxVis = " + to_string(maxVis) + ";" +
            " minVisBand = " + to_string(minVisBand) + ";" +
@@ -263,7 +232,6 @@ std::string BaseInfo::toString() const
            " drawOffset = " + to_string(drawOffset) + ";" +
            " drawPriority = " + to_string(drawPriority) + ";" +
            " enable = " + (enable ? "yes" : "no") + ";" +
-           " fade = " + to_string(fade) + ";" +
            " fadeIn = " + to_string(fadeIn) + ";" +
            " fadeOut = " + to_string(fadeOut) + ";" +
            " fadeOutTime = " + to_string(fadeOutTime) + ";" +

--- a/common/WhirlyGlobeLib/src/BillboardManager.cpp
+++ b/common/WhirlyGlobeLib/src/BillboardManager.cpp
@@ -57,18 +57,6 @@ Billboard::Billboard() :
 {
 }
     
-BillboardSceneRep::BillboardSceneRep() :
-    Identifiable(),
-    fade(0.0f)
-{
-}
-
-BillboardSceneRep::BillboardSceneRep(SimpleIdentity inId) :
-    Identifiable(inId),
-    fade(0.0f)
-{
-}
-
 void BillboardSceneRep::clearContents(SelectionManagerRef &selectManager,ChangeSet &changes,TimeInterval when)
 {
     for (const auto it: drawIDs){
@@ -197,7 +185,7 @@ SimpleIdentity BillboardManager::addBillboards(const std::vector<Billboard*> &bi
     const auto selectManager = scene->getManager<SelectionManager>(kWKSelectionManager);
 
     auto sceneRep = new BillboardSceneRep();
-    sceneRep->fade = (float)billboardInfo.fade;
+    sceneRep->fadeOut = billboardInfo.fadeOut;
 
     CoordSystemDisplayAdapter *coordAdapter = scene->getCoordAdapter();
 
@@ -289,7 +277,7 @@ void BillboardManager::removeBillboards(const SimpleIDSet &billIDs,ChangeSet &ch
     std::lock_guard<std::mutex> guardLock(lock);
 
     const TimeInterval curTime = scene->getCurrentTime();
-    for (auto billID : billIDs)
+    for (const auto billID : billIDs)
     {
         BillboardSceneRep dummyRep(billID);
         auto it = sceneReps.find(&dummyRep);
@@ -298,16 +286,16 @@ void BillboardManager::removeBillboards(const SimpleIDSet &billIDs,ChangeSet &ch
             auto *sceneRep = *it;
 
             TimeInterval removeTime = 0.0;
-            if (sceneRep->fade > 0.0)
+            if (sceneRep->fadeOut > 0.0)
             {
-                for (auto id : sceneRep->drawIDs)
+                for (const auto id : sceneRep->drawIDs)
                 {
-                    changes.push_back(new FadeChangeRequest(id, curTime, curTime+sceneRep->fade));
+                    changes.push_back(new FadeChangeRequest(id, curTime, curTime+sceneRep->fadeOut));
                 }
                 
-                removeTime = curTime + sceneRep->fade;
+                removeTime = curTime + sceneRep->fadeOut;
             }
-            
+
             sceneRep->clearContents(selectManager,changes,removeTime);
             sceneReps.erase(it);
             delete sceneRep;

--- a/common/WhirlyGlobeLib/src/LabelRenderer.cpp
+++ b/common/WhirlyGlobeLib/src/LabelRenderer.cpp
@@ -222,7 +222,10 @@ void LabelRenderer::render(PlatformThreadInfo *threadInfo,
             if (labelInfo->fadeIn > 0.0)
                 screenShape->setFade(curTime+labelInfo->fadeIn, curTime);
             else if (labelInfo->fadeOutTime != 0.0)
-                screenShape->setFade(labelInfo->fadeOutTime, labelInfo->fadeOutTime+labelInfo->fadeOut);
+            {
+                // up<down=fade out
+                screenShape->setFade(/*up=*/labelInfo->fadeOutTime, /*down=*/labelInfo->fadeOutTime+labelInfo->fadeOut);
+            }
             if (label->isSelectable && label->selectID != EmptyIdentity)
                 screenShape->setId(label->selectID);
             screenShape->setWorldLoc(coordAdapter->localToDisplay(coordAdapter->getCoordSystem()->geographicToLocal3d(label->loc)));

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleLine.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleLine.cpp
@@ -222,7 +222,8 @@ void MapboxVectorLayerLine::buildObjects(PlatformThreadInfo *inst,
     vecInfo.hasExp = true;
     vecInfo.coordType = WideVecCoordScreen;
     vecInfo.programID = styleSet->wideVectorProgramID;
-    vecInfo.fade = fade;
+    vecInfo.fadeIn = fade;
+    vecInfo.fadeOut = fade;
     vecInfo.zoomSlot = styleSet->zoomSlot;
     vecInfo.color = *color;
     vecInfo.width = (float)width;

--- a/common/WhirlyGlobeLib/src/MarkerManager.cpp
+++ b/common/WhirlyGlobeLib/src/MarkerManager.cpp
@@ -319,7 +319,8 @@ SimpleIdentity MarkerManager::addMarkers(const std::vector<Marker *> &markers,co
             }
             else if (markerInfo.fadeOut > 0.0 && markerInfo.fadeOutTime > 0.0)
             {
-                shape->setFade(markerInfo.fadeOutTime, markerInfo.fadeOutTime+markerInfo.fadeOut);
+                // up<down=fade out
+                shape->setFade(/*up=*/markerInfo.fadeOutTime, /*down=*/markerInfo.fadeOutTime+markerInfo.fadeOut);
             }
 
             shape->setVisibility((float)markerInfo.minVis, (float)markerInfo.maxVis);

--- a/common/WhirlyGlobeLib/src/ShapeDrawableBuilder.cpp
+++ b/common/WhirlyGlobeLib/src/ShapeDrawableBuilder.cpp
@@ -143,11 +143,18 @@ void ShapeDrawableBuilder::flush()
         {
             drawable->setLocalMbr(drawMbr);
 
-            if (shapeInfo.fade > 0.0)
+            if (shapeInfo.fadeIn > 0.0)
             {
+                // fadeDown < fadeUp : fading in
                 const TimeInterval curTime = sceneRender->getScene()->getCurrentTime();
-                drawable->setFade(curTime,curTime+shapeInfo.fade);
+                drawable->setFade(curTime,curTime+shapeInfo.fadeIn);
             }
+            else if (shapeInfo.fadeOut > 0.0 && shapeInfo.fadeOutTime > 0.0)
+            {
+                // fadeUp < fadeDown : fading out
+                drawable->setFade(/*down=*/shapeInfo.fadeOutTime+shapeInfo.fadeOut, /*up=*/shapeInfo.fadeOutTime);
+            }
+
             drawables.push_back(drawable);
         }
         drawable = nullptr;
@@ -407,11 +414,18 @@ void ShapeDrawableBuilderTri::flush()
         {
             drawable->setLocalMbr(drawMbr);
 
-            if (shapeInfo.fade > 0.0)
+            if (shapeInfo.fadeIn > 0.0)
             {
+                // fadeDown < fadeUp : fading in
                 const TimeInterval curTime = sceneRender->getScene()->getCurrentTime();
-                drawable->setFade(curTime,curTime+shapeInfo.fade);
+                drawable->setFade(curTime,curTime+shapeInfo.fadeIn);
             }
+            else if (shapeInfo.fadeOut > 0.0 && shapeInfo.fadeOutTime > 0.0)
+            {
+                // fadeUp < fadeDown : fading out
+                drawable->setFade(/*down=*/shapeInfo.fadeOutTime+shapeInfo.fadeOut, /*up=*/shapeInfo.fadeOutTime);
+            }
+
             drawables.push_back(drawable);
         }
         drawable = NULL;

--- a/common/WhirlyGlobeLib/src/ShapeManager.cpp
+++ b/common/WhirlyGlobeLib/src/ShapeManager.cpp
@@ -692,7 +692,7 @@ SimpleIdentity ShapeManager::addShapes(const std::vector<Shape*> &shapes, const 
     auto selectManager = scene->getManager<SelectionManager>(kWKSelectionManager);
 
     auto sceneRep = std::make_unique<ShapeSceneRep>();
-    sceneRep->fade = (float)shapeInfo.fade;
+    sceneRep->fadeOut = (float)shapeInfo.fadeOut;
 
     // Figure out a good center
     Point3d center(0,0,0);
@@ -757,16 +757,20 @@ void ShapeManager::removeShapes(const SimpleIDSet &shapeIDs,ChangeSet &changes)
     std::lock_guard<std::mutex> guardLock(lock);
 
     const TimeInterval curTime = scene->getCurrentTime();
-    for (auto shapeID : shapeIDs) {
+    for (auto shapeID : shapeIDs)
+    {
         ShapeSceneRep dummyRep(shapeID);
         auto sit = shapeReps.find(&dummyRep);
-        if (sit != shapeReps.end()) {
+        if (sit != shapeReps.end())
+        {
             ShapeSceneRep *shapeRep = *sit;
-
             TimeInterval removeTime = 0.0;
-            if (shapeRep->fade > 0.0) {
-                for (auto idIt = shapeRep->drawIDs.begin(); idIt != shapeRep->drawIDs.end(); ++idIt)
-                    changes.push_back(new FadeChangeRequest(*idIt, curTime, curTime+shapeRep->fade));
+            if (shapeRep->fadeOut > 0.0)
+            {
+                for (auto id : shapeRep->drawIDs)
+                {
+                    changes.push_back(new FadeChangeRequest(id, curTime, curTime+shapeRep->fadeOut));
+                }
             }
             
 			shapeRep->clearContents(selectManager, changes, removeTime);

--- a/common/WhirlyGlobeLib/src/VectorManager.cpp
+++ b/common/WhirlyGlobeLib/src/VectorManager.cpp
@@ -240,11 +240,18 @@ public:
                     drawable->setMatrix(&transMat);
                 }
                 
-                if (vecInfo->fade > 0.0)
+                if (vecInfo->fadeIn > 0.0)
                 {
+                    // fadeDown < fadeUp : fading in
                     const TimeInterval curTime = scene->getCurrentTime();
-                    drawable->setFade(curTime,curTime+vecInfo->fade);
+                    drawable->setFade(curTime,curTime+vecInfo->fadeIn);
                 }
+                else if (vecInfo->fadeOut > 0.0 && vecInfo->fadeOutTime > 0.0)
+                {
+                    // fadeUp < fadeDown : fading out
+                    drawable->setFade(/*down=*/vecInfo->fadeOutTime+vecInfo->fadeOut, /*up=*/vecInfo->fadeOutTime);
+                }
+
                 changeRequests.push_back(new AddDrawableReq(drawable->getDrawable()));
             }
             drawable = nullptr;
@@ -555,13 +562,19 @@ public:
                     drawable->setMatrix(trans.matrix());
                 }
                 sceneRep->drawIDs.insert(drawable->getDrawableID());
-                
-                if (vecInfo->fade > 0.0)
+
+                if (vecInfo->fadeIn > 0.0)
                 {
+                    // fadeDown < fadeUp = fading in
                     const TimeInterval curTime = scene->getCurrentTime();
-                    drawable->setFade(curTime,curTime+vecInfo->fade);
+                    drawable->setFade(curTime,curTime+vecInfo->fadeIn);
                 }
-                
+                else if (vecInfo->fadeOutTime > 0.0)
+                {
+                    // fadeUp < fadeDown = fading out
+                    drawable->setFade(/*down=*/vecInfo->fadeOutTime+vecInfo->fadeOut, /*up=*/vecInfo->fadeOutTime);
+                }
+
                 changeRequests.push_back(new AddDrawableReq(drawable->getDrawable()));
             }
             drawable = nullptr;
@@ -598,7 +611,7 @@ SimpleIdentity VectorManager::addVectors(const ShapeSet *shapes, const VectorInf
         return EmptyIdentity;
     
     auto *sceneRep = new VectorSceneRep();
-    sceneRep->fade = (float)vecInfo.fade;
+    sceneRep->fadeOut = (float)vecInfo.fadeOut;
 
     // Look for per vector colors
     bool doColors = false;
@@ -795,7 +808,7 @@ SimpleIdentity VectorManager::addVectors(const std::vector<VectorShapeRef> &shap
     }
 
     auto sceneRep = std::make_unique<VectorSceneRep>();
-    sceneRep->fade = (float)vecInfo.fade;
+    sceneRep->fadeOut = (float)vecInfo.fadeOut;
 
     // Look for per vector colors
     bool doColors = (vecInfo.colorExp || vecInfo.opacityExp);
@@ -1072,8 +1085,8 @@ void VectorManager::removeVectors(SimpleIDSet &vecIDs,ChangeSet &changes)
         std::unique_ptr<VectorSceneRep> sceneRep(*it);
         vectorReps.erase(it);
 
-        const bool fade = (sceneRep->fade > 0.0);
-        const auto fadeT = fade ? (curTime + sceneRep->fade) : 0.0;
+        const bool fade = (sceneRep->fadeOut > 0.0);
+        const auto fadeT = fade ? (curTime + sceneRep->fadeOut) : 0.0;
 
         // Make a copy and merge the IDs into it
         allIDs.clear();

--- a/common/WhirlyGlobeLib/src/WideVectorManager.cpp
+++ b/common/WhirlyGlobeLib/src/WideVectorManager.cpp
@@ -961,15 +961,15 @@ struct WideVectorDrawableConstructor
         const TimeInterval curTime = scene->getCurrentTime();
         
         auto *sceneRep = new WideVectorSceneRep();
-        sceneRep->fade = (float)vecInfo->fade;
+        sceneRep->fadeOut = (float)vecInfo->fadeOut;
         for (const auto &theDrawable : drawables)
         {
             if (auto drawID = theDrawable->getBasicDrawableID())
                 sceneRep->drawIDs.insert(drawID);
             if (auto drawID = theDrawable->getInstanceDrawableID())
                 sceneRep->instIDs.insert(drawID);
-            if (vecInfo->fade > 0.0)
-                theDrawable->setFade(curTime, curTime + vecInfo->fade);
+            if (vecInfo->fadeOut > 0.0)
+                theDrawable->setFade(curTime, curTime + vecInfo->fadeOut);
             if (auto draw = theDrawable->getBasicDrawable())
                 changes.push_back(new AddDrawableReq(draw));
             if (auto draw = theDrawable->getInstanceDrawable())
@@ -1283,7 +1283,7 @@ void WideVectorManager::removeVectors(SimpleIDSet &vecIDs,ChangeSet &changes)
             WideVectorSceneRep *sceneRep = *it;
 
             TimeInterval removeTime = 0.0;
-            if (sceneRep->fade > 0.0)
+            if (sceneRep->fadeOut > 0.0)
             {
                 std::unordered_set<SimpleIdentity> allIDs(sceneRep->drawIDs.size() + sceneRep->instIDs.size());
                 allIDs.insert(sceneRep->drawIDs.begin(), sceneRep->drawIDs.end());
@@ -1291,10 +1291,10 @@ void WideVectorManager::removeVectors(SimpleIDSet &vecIDs,ChangeSet &changes)
 
                 for (const auto id : allIDs)
                 {
-                    changes.push_back(new FadeChangeRequest(id, curTime, curTime+sceneRep->fade));
+                    changes.push_back(new FadeChangeRequest(id, curTime, curTime+sceneRep->fadeOut));
                 }
                 
-                removeTime = curTime + sceneRep->fade;
+                removeTime = curTime + sceneRep->fadeOut;
             }
             
             sceneRep->clearContents(changes,removeTime);

--- a/ios/apps/AutoTester/AutoTester.xcodeproj/project.pbxproj
+++ b/ios/apps/AutoTester/AutoTester.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		2BFC7E511D132DCB0040E2A3 /* ScreenMarkersTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BFC7E501D132DCB0040E2A3 /* ScreenMarkersTestCase.m */; };
 		31041A2227A36D53004B25E1 /* WhirlyGlobe.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8F858AFC1E7FE60C00037D4E /* WhirlyGlobe.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		31041A3E27A4AE76004B25E1 /* ActiveObjectTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31041A3D27A4AE76004B25E1 /* ActiveObjectTestCase.swift */; };
+		311C6A0B27B1C3FC0016BC7E /* FadeTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 311C6A0927B1C3FC0016BC7E /* FadeTestCase.swift */; };
 		311E0A9C2680F597007BE16F /* ATS_Route.shp in Resources */ = {isa = PBXBuildFile; fileRef = 311E0A902680F597007BE16F /* ATS_Route.shp */; };
 		311E0A9D2680F597007BE16F /* Airspace_Boundary.dbf in Resources */ = {isa = PBXBuildFile; fileRef = 311E0A912680F597007BE16F /* Airspace_Boundary.dbf */; };
 		311E0A9E2680F597007BE16F /* Airspace_Boundary.shx in Resources */ = {isa = PBXBuildFile; fileRef = 311E0A922680F597007BE16F /* Airspace_Boundary.shx */; };
@@ -720,6 +721,7 @@
 		2BFC7E501D132DCB0040E2A3 /* ScreenMarkersTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ScreenMarkersTestCase.m; sourceTree = "<group>"; };
 		31041A3D27A4AE76004B25E1 /* ActiveObjectTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveObjectTestCase.swift; sourceTree = "<group>"; };
 		311C6A0227B193AE0016BC7E /* SwiftBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftBridge.h; sourceTree = "<group>"; };
+		311C6A0927B1C3FC0016BC7E /* FadeTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FadeTestCase.swift; sourceTree = "<group>"; };
 		311E0A902680F597007BE16F /* ATS_Route.shp */ = {isa = PBXFileReference; lastKnownFileType = file; name = ATS_Route.shp; path = ../../../resources/vectors/faa/ATS_Route.shp; sourceTree = SOURCE_ROOT; };
 		311E0A912680F597007BE16F /* Airspace_Boundary.dbf */ = {isa = PBXFileReference; lastKnownFileType = file; name = Airspace_Boundary.dbf; path = ../../../resources/vectors/faa/Airspace_Boundary.dbf; sourceTree = SOURCE_ROOT; };
 		311E0A922680F597007BE16F /* Airspace_Boundary.shx */ = {isa = PBXFileReference; lastKnownFileType = file; name = Airspace_Boundary.shx; path = ../../../resources/vectors/faa/Airspace_Boundary.shx; sourceTree = SOURCE_ROOT; };
@@ -1364,6 +1366,7 @@
 				311E0AAA26865D2C007BE16F /* ESRIRemoteTestCase.swift */,
 				2BDEB3001C924842003259B3 /* ExtrudedModelTestCase.h */,
 				2BDEB3011C924842003259B3 /* ExtrudedModelTestCase.m */,
+				311C6A0927B1C3FC0016BC7E /* FadeTestCase.swift */,
 				E5679F461CB72DE800369A15 /* FindHeightTestCase.h */,
 				E5679F471CB72DE800369A15 /* FindHeightTestCase.m */,
 				2B249F3E23F4A82600CFA3D0 /* GeographyClass.swift */,
@@ -2657,6 +2660,7 @@
 				2BBCE41C2220A4170013E158 /* PagingLayerTestCase.m in Sources */,
 				2B4B30AB2395E0DE00854073 /* StartupShutdownTestCase.swift in Sources */,
 				D8F2FE2C1BE7CAD30058A310 /* MegaMarkersTestCase.m in Sources */,
+				311C6A0B27B1C3FC0016BC7E /* FadeTestCase.swift in Sources */,
 				31D328AD26387E7900456B93 /* GreatCircleTestCase.swift in Sources */,
 				2B4B30AA2395E0DE00854073 /* MapboxTestCase.swift in Sources */,
 				D8341A711BE2C8D200411A46 /* VectorsTestCase.mm in Sources */,

--- a/ios/apps/AutoTester/AutoTester/StartupViewController.swift
+++ b/ios/apps/AutoTester/AutoTester/StartupViewController.swift
@@ -25,6 +25,7 @@ class StartupViewController: UITableViewController, UIPopoverPresentationControl
         ClusteredMarkersTestCase(),
         ESRIRemoteTestCase(),
         ExtrudedModelTestCase(),
+        FadeTestCase(),
         FindHeightTestCase(),
         GeoJSONStyleTestCase(),
         GeographyClassTestCase(),

--- a/ios/apps/AutoTester/AutoTester/testCases/FadeTestCase.swift
+++ b/ios/apps/AutoTester/AutoTester/testCases/FadeTestCase.swift
@@ -1,0 +1,135 @@
+//
+//  FadeTestCase.swift
+//  AutoTester
+//
+//  Created by Tim Sylvester on 02/07/22.
+//  Copyright 2022 mousebird consulting. All rights reserved.
+//
+
+import Foundation
+import WhirlyGlobe
+
+class FadeTestCase: MaplyTestCase {
+    
+    override init() {
+        super.init()
+        self.name = "Fade"
+        self.implementations = [.globe,.map]
+    }
+
+    func setup() {
+        if let vc = baseViewController {
+            addStuff(vc)
+        }
+        timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            if let self = self, let vc = self.baseViewController {
+                self.addStuff(vc)
+            }
+        }
+    }
+    
+    func addStuff(_ vc: MaplyBaseViewController) {
+        let oldObjs = [MaplyComponentObject](self.objs)
+        var newObjs = [MaplyComponentObject]()
+        let fillDesc = [
+            kMaplyEnable: false,
+            kMaplyColor: UIColor.red.withAlphaComponent(0.5),
+            kMaplyFilled: true
+        ] as [AnyHashable: Any]
+        let lineDesc = [
+            kMaplyEnable: false,
+            kMaplyColor: UIColor.magenta.withAlphaComponent(0.75),
+            kMaplyFilled: false
+        ] as [AnyHashable: Any]
+
+        do {
+            var coords = [
+                MaplyCoordinateMakeWithDegrees(-90, 40+offset),
+                MaplyCoordinateMakeWithDegrees(-89, 42+offset),
+                MaplyCoordinateMakeWithDegrees(-88, 40+offset),
+            ]
+            let area = MaplyVectorObject.init(areal: &coords, numCoords: Int32(coords.count), attributes: nil)
+            // Fade in over two seconds, fade out over two seconds when removed
+            let desc = [ kMaplyFade: 2.0 ] as [AnyHashable: Any]
+            if let obj = vc.addVectors([area], desc: fillDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+            if let obj = vc.addVectors([area], desc: lineDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+        }
+
+        do {
+            var coords = [
+                MaplyCoordinateMakeWithDegrees(-88, 40+offset),
+                MaplyCoordinateMakeWithDegrees(-87, 42+offset),
+                MaplyCoordinateMakeWithDegrees(-86, 40+offset),
+            ]
+            let area = MaplyVectorObject.init(areal: &coords, numCoords: Int32(coords.count), attributes: nil)
+            // Fade in over two seconds
+            let desc = [ kMaplyFadeIn: 2.0 ] as [AnyHashable: Any]
+            if let obj = vc.addVectors([area], desc: fillDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+            if let obj = vc.addVectors([area], desc: lineDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+        }
+
+        do {
+            var coords = [
+                MaplyCoordinateMakeWithDegrees(-86, 40+offset),
+                MaplyCoordinateMakeWithDegrees(-85, 42+offset),
+                MaplyCoordinateMakeWithDegrees(-84, 40+offset),
+            ]
+            let area = MaplyVectorObject.init(areal: &coords, numCoords: Int32(coords.count), attributes: nil)
+            // Fade out over two seconds (when removed)
+            let desc = [ kMaplyFadeOut: 2.0 ] as [AnyHashable: Any]
+            if let obj = vc.addVectors([area], desc: fillDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+            if let obj = vc.addVectors([area], desc: lineDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+        }
+
+        do {
+            var coords = [
+                MaplyCoordinateMakeWithDegrees(-84, 40+offset),
+                MaplyCoordinateMakeWithDegrees(-83, 42+offset),
+                MaplyCoordinateMakeWithDegrees(-82, 40+offset),
+            ]
+            let area = MaplyVectorObject.init(areal: &coords, numCoords: Int32(coords.count), attributes: nil)
+            let desc = [
+                // Fade out over two seconds, starting one second from now
+                kMaplyFadeOut: 2.0,
+                kMaplyFadeOutTime: CFAbsoluteTimeGetCurrent() + 1.0,
+            ] as [AnyHashable: Any]
+            if let obj = vc.addVectors([area], desc: fillDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+            if let obj = vc.addVectors([area], desc: lineDesc.merging(desc) { $1 }, mode: .current) { newObjs.append(obj) }
+        }
+
+        // todo: Add other stuff that supports fades: wide vectors, labels, markers, shapes, ...
+
+        offset = (offset == 0.0) ? 2.0 : 0.0
+
+        vc.enable(newObjs, mode: .current)
+        vc.remove(oldObjs)
+        objs = newObjs
+    }
+
+    override func setUpWithGlobe(_ globeVC: WhirlyGlobeViewController) {
+        baseCase.setUpWithGlobe(globeVC)
+        globeVC.animate(toPosition: MaplyCoordinateMakeWithDegrees(-80, 40), height: 0.5, heading: 0, time: 3)
+        setup()
+    }
+
+    override func setUpWithMap(_ mapVC: MaplyViewController) {
+        baseCase.setUpWithMap(mapVC)
+        setup()
+        mapVC.animate(toPosition: MaplyCoordinateMakeWithDegrees(-80, 40), height: 0.5, time: 3)
+    }
+
+    override func stop() {
+        timer?.invalidate()
+        timer = nil
+        baseViewController?.remove(objs, mode: MaplyThreadMode.current);
+        objs.removeAll()
+        baseCase.stop()
+        super.stop()
+    }
+
+    let baseCase = CartoDBLightTestCase()
+    var objs = [MaplyComponentObject]()
+    var timer: Timer?
+    var offset = Float(0.0)
+}
+

--- a/ios/library/WhirlyGlobeLib/src/wkDefaultShaders.metal
+++ b/ios/library/WhirlyGlobeLib/src/wkDefaultShaders.metal
@@ -41,19 +41,17 @@ float calculateFade(constant Uniforms &uni,
                 fade = 1.0;
             else
                 fade = (uni.currentTime - uniA.fadeDown)/(uniA.fadeUp - uniA.fadeDown);
-    } else {
-        if (uniA.fadeUp < uniA.fadeDown)
-        {
-            // Heading to 0
-            if (uni.currentTime < uniA.fadeUp)
-                fade = 1.0;
+    } else if (uniA.fadeUp < uniA.fadeDown) {
+        // Heading to 0
+        if (uni.currentTime < uniA.fadeUp)
+            fade = 1.0;
+        else
+            if (uni.currentTime > uniA.fadeDown)
+                fade = 0.0;
             else
-                if (uni.currentTime > uniA.fadeDown)
-                    fade = 0.0;
-                else
-                    fade = 1.0-(uni.currentTime - uniA.fadeUp)/(uniA.fadeDown - uniA.fadeUp);
-        }
+                fade = 1.0-(uni.currentTime - uniA.fadeUp)/(uniA.fadeDown - uniA.fadeUp);
     }
+
     // Deal with the range based fade
     if (uni.height > 0.0)
     {


### PR DESCRIPTION
`BaseInfo::fade` was used as the default for `fadeIn` and `fadeOut` but also stored separately.  Various code would then use `fade` directly, instead of the potentially-overridden -in or -out option, as appropriate.  So I removed `fade` so that everything references one of those explicitly.

Some objects use `setFade(up,down)` and some use `setFade(down,up)`, which is confusing.  I labeled them for now, as I don't really have time to thoroughly normalize them.  One point for named parameters, _a la_ Swift.

Add timed fade-out support for vectors, shapes, lofts.  Still many objects without any support.
New fade test case, but only for vectors.  Needs shapes, wide vectors, etc..

Resolves #1457, probably.