### PR TITLE
Fix attribute constant aliases

### DIFF
--- a/ios/apps/AutoTester/AutoTester/testCases/ModelsTestCase.swift
+++ b/ios/apps/AutoTester/AutoTester/testCases/ModelsTestCase.swift
@@ -61,9 +61,18 @@ class ModelsTestCase: MaplyTestCase {
 					modelInstances.append(mInst)
 
 				}
-				globeVC.addModelInstances(modelInstances, desc: [:], mode: MaplyThreadMode.current)
+                let h = Float(0.1)
+                let desc = [
+                    kMaplyEnable: true,
+                    kMaplyViewerMinDist: 1.01,
+                    kMaplyViewerMaxDist: 1.01 + h,
+                    kMaplyViewableCenterX: 0.0,
+                    kMaplyViewableCenterY: 0.0,
+                    kMaplyViewableCenterZ: 0.0,
+                ] as [AnyHashable:Any]
+				globeVC.addModelInstances(modelInstances, desc: desc, mode: MaplyThreadMode.current)
 				globeVC.animate(toPosition: MaplyCoordinateMakeWithDegrees(-94.58, 39.1) ,time: 1.0)
-				globeVC.height = 0.1
+				globeVC.height = h
 			}
 		}
 	}

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplySharedAttributes.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/control/MaplySharedAttributes.mm
@@ -45,9 +45,9 @@ NSString* const kMaplyMinVis = MaplyMinVis;
 /// Maximum point at which a feature is visible.  Takes an NSNumber float.  The radius of the globe is 1.0
 NSString* const kMaplyMaxVis = MaplyMaxVis;
 /// Minimum distance from the viewer at which to display geometry.
-NSString* const kMaplyViewerMinDist = MaplyMinVisBand;
+NSString* const kMaplyViewerMinDist = MaplyMinViewerDist;
 /// Maximum distance from the viewer at which to display geometry.
-NSString* const kMaplyViewerMaxDist = MaplyMaxVisBand;
+NSString* const kMaplyViewerMaxDist = MaplyMaxViewerDist;
 /// Center to use when evaluating distance to viewable geometry (X)
 NSString* const kMaplyViewableCenterX = MaplyViewableCenterX;
 /// Center to use when evaluating distance to viewable geometry (Y)


### PR DESCRIPTION
Seems like a straightforward copy/paste error.

@paulgee31 Note that the center has to be set to calculate the distance
