### PR TITLE
Fix an issue when maply could not call delegate method on gesture

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/MaplyPinchDelegate.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/gestures/MaplyPinchDelegate.mm
@@ -47,10 +47,6 @@ using namespace Maply;
 - (void)pinchGesture:(id)sender
 {
     UIPinchGestureRecognizer *pinch = sender;
-    if ([pinch numberOfTouches] < 2)
-    {
-        return;
-    }
     UIGestureRecognizerState theState = pinch.state;
     UIView<WhirlyKitViewWrapper> *wrapView = (UIView<WhirlyKitViewWrapper> *)pinch.view;
     SceneRenderer *sceneRenderer = wrapView.renderer;
@@ -63,14 +59,16 @@ using namespace Maply;
             startZ = self.mapView->getLoc().z();
             
             //calculate center between touches, in screen and map coords
-            CGPoint t0 = [pinch locationOfTouch:0 inView:pinch.view];
-            CGPoint t1 = [pinch locationOfTouch:1 inView:pinch.view];
-            startingMidPoint.x() = (t0.x + t1.x) / 2.0;
-            startingMidPoint.y() = (t0.y + t1.y) / 2.0;
-            Eigen::Matrix4d modelTrans = self.mapView->calcFullMatrix();
-            Point2f frameSize = sceneRenderer->getFramebufferSizeScaled();
-            self.mapView->pointOnPlaneFromScreen(startingMidPoint, &modelTrans, frameSize, &startingGeoPoint, true);
-
+            if ([pinch numberOfTouches] >= 2) {
+                CGPoint t0 = [pinch locationOfTouch:0 inView:pinch.view];
+                CGPoint t1 = [pinch locationOfTouch:1 inView:pinch.view];
+                startingMidPoint.x() = (t0.x + t1.x) / 2.0;
+                startingMidPoint.y() = (t0.y + t1.y) / 2.0;
+                Eigen::Matrix4d modelTrans = self.mapView->calcFullMatrix();
+                Point2f frameSize = sceneRenderer->getFramebufferSizeScaled();
+                self.mapView->pointOnPlaneFromScreen(startingMidPoint, &modelTrans, frameSize, &startingGeoPoint, true);
+            }
+            
             self.mapView->cancelAnimation();
             [[NSNotificationCenter defaultCenter] postNotificationName:kZoomGestureDelegateDidStart object:self.mapView->tag];
         }


### PR DESCRIPTION
This fixes an issue when maply could not call delegate method on gesture map moving because of pinch gesture early exit if less than 2 touches that could happen on 2 fingers zoom introduced in https://github.com/mousebird-consulting-inc/WhirlyGlobe/pull/1503. This PR fixes possible crash on pinch gesture but keeps the logic on ending gesture including notifying the delegate.